### PR TITLE
[fix] Update Dockerfile CMD to ensure dependencies are installed befo…

### DIFF
--- a/admin/Dockerfile
+++ b/admin/Dockerfile
@@ -19,4 +19,4 @@ COPY . .
 EXPOSE 3000
 
 # next がコマンドとして見つからない場合に備えて、npx を使用
-CMD ["npx", "next", "dev"]
+CMD ["sh", "-c", "npm install && ./node_modules/.bin/next dev"]

--- a/user/Dockerfile
+++ b/user/Dockerfile
@@ -56,7 +56,7 @@ EXPOSE 5173
 
 # ------ 開発用 -------
 # Viteの開発サーバーを起動
-CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0"]
+CMD ["sh", "-c", "npm install && ./node_modules/.bin/vite --host 0.0.0.0"]
 # CMD ["pnpm", "run", "dev", "--", "--host", "0.0.0.0"]
 # CMD ["pnpm", "run", "dev"]
 


### PR DESCRIPTION
## Summary
  - `admin/Dockerfile` と `user/Dockerfile` の CMD
  を修正し、コンテナ起動時に `npm install` を実行するよう変更
  - bind mount (`./admin:/app`) が Docker イメージの node_modules
  を上書きし、anonymous volume のシードが機能しないことで `next` /
   `vite` コマンドが見つからなかった問題を解決
  - `npx` が最新の `next@16.2.6`
  をダウンロードしてしまう問題も合わせて解消（インストール済みの
  `./node_modules/.bin/next` を直接呼び出すよう変更）
  
  ## Test plan

  - [ ] `docker compose down -v && docker compose up --build`
  を実行
  - [ ] `admin-app | ✓ Ready` のログが出ることを確認 →
  http://localhost:3000 にアクセス
  - [ ] `r3f-app | VITE` のログが出ることを確認 →
  http://localhost:5173 にアクセス