### PR TITLE
Feat/walt/admin auth

### DIFF
--- a/admin/middleware.ts
+++ b/admin/middleware.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export function middleware(req: NextRequest) {
+  const { pathname } = req.nextUrl;
+
+  if (
+    pathname.startsWith("/_next/static") ||
+    pathname.startsWith("/_next/image") ||
+    pathname === "/favicon.ico"
+  ) {
+    return NextResponse.next();
+  }
+
+  const authHeader = req.headers.get("authorization");
+
+  if (authHeader?.startsWith("Basic ")) {
+    const base64 = authHeader.slice("Basic ".length);
+    const decoded = atob(base64);
+    const colonIndex = decoded.indexOf(":");
+    if (colonIndex !== -1) {
+      const username = decoded.slice(0, colonIndex);
+      const password = decoded.slice(colonIndex + 1);
+
+      const expectedUsername = process.env.ADMIN_USERNAME ?? "";
+      const expectedPassword = process.env.ADMIN_PASSWORD ?? "";
+
+      if (username === expectedUsername && password === expectedPassword) {
+        return NextResponse.next();
+      }
+    }
+  }
+
+  return new NextResponse("Unauthorized", {
+    status: 401,
+    headers: {
+      "WWW-Authenticate": 'Basic realm="Admin"',
+    },
+  });
+}
+
+export const config = {
+  matcher: ["/((?!_next/static|_next/image|favicon.ico).*)"],
+};

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -28,6 +28,8 @@ services:
       - /app/.next
     environment:
       - NEXT_PUBLIC_API_URL=http://localhost:8080
+      - ADMIN_USERNAME=${ADMIN_USERNAME}
+      - ADMIN_PASSWORD=${ADMIN_PASSWORD}
     networks:
       - app_network
     depends_on:


### PR DESCRIPTION
## 概要
    
  admin アプリへの不正アクセスを防ぐため、Next.js middleware
  による HTTP Basic 認証を実装しました。

  ## 変更内容

  ### 新規作成
  - `admin/middleware.ts` — HTTP Basic 認証ミドルウェア

  ### 変更
  - `docker-compose.yaml` — admin サービスに `ADMIN_USERNAME` /
  `ADMIN_PASSWORD` 環境変数を追加
  - `.env` — `ADMIN_USERNAME` / `ADMIN_PASSWORD`
  を追加（デフォルト値: `admin` / `admin`）

  ## 仕様

  - 環境変数 `ADMIN_USERNAME` / `ADMIN_PASSWORD` で認証情報を管理
  - 認証失敗時はブラウザのネイティブ Basic Auth
  ダイアログを表示（401 + `WWW-Authenticate` ヘッダー）
  - `/_next/static`、`/_next/image`、`/favicon.ico` は認証対象外
  - Edge Runtime 対応（`Buffer` 不使用、`atob()` を使用）
  - パスワードに `:`
  が含まれる場合も正しく動作（最初のコロンのみで分割）

  ## 動作確認
    
  - [x] `docker compose up` 後、`http://localhost:3000` で Basic
  Auth ダイアログが表示される
  - [x] 正しい認証情報を入力すると管理画面が表示される
  - [x] 誤った認証情報では 401 が返る
  - [x] 静的アセット（`/_next/static/`）は認証なしでロードされる
