### PR TITLE
[fix] Adjust resolutionScale for performance based on devicePixelRatio

### DIFF
--- a/user/src/canvas/HomeCanvas.tsx
+++ b/user/src/canvas/HomeCanvas.tsx
@@ -166,7 +166,7 @@ const CanvasSetup = forwardRef<CanvasSetupHandle>(( _, ref) => {
           width={window.innerWidth}    // ブルームの幅
           height={window.innerHeight}  // ブルームの高さ
           mipmapBlur={true}            // ミップマップを使用してブルームを適用
-          resolutionScale={1.5}        // 解像度を上げる（デフォルト1）
+          resolutionScale={window.devicePixelRatio > 2 ? 1.0 : 1.5}  // DPR > 2 はパフォーマンス優先
         />
       </EffectComposer>
     </>


### PR DESCRIPTION
---
  [fix] Bloom の resolutionScale を DPR 
  に応じて動的に設定しパフォーマンスを改善

  背景

  Bloom エフェクトの resolutionScale が 1.5
  固定だったため、DPR（devicePixelRatio）が 2 を超えるハイエンドス
  マートフォンで描画負荷が高くなりカクつく問題があった。

  変更内容

  window.devicePixelRatio を参照し、端末の性能に応じて
  resolutionScale を切り替えるようにした。

  - DPR > 2 → 1.0（ハイエンド端末はパフォーマンス優先）
  - DPR ≤ 2 → 1.5（標準端末は変更前と同じ画質を維持）