### PR TITLE
[fix] improve service startup order with health checks for db and sea…

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -60,8 +60,10 @@ services:
     networks:
       - app_network
     depends_on:
-      - db
-      - seaweedfs
+      db:
+        condition: service_healthy
+      seaweedfs:
+        condition: service_healthy
 
   db:
     image: postgres:15
@@ -94,6 +96,12 @@ services:
     networks:
       - app_network
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:8333/"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 10s
 
   swagger-ui:
     image: swaggerapi/swagger-ui


### PR DESCRIPTION
## 概要

  `docker compose up` のたびに API コンテナが起動に失敗し、毎回
  `docker restart ar-hanabi-mobile-app-1`
  による手動対応が必要になっていた問題を修正。
    
  ## 原因

  `docker-compose.yaml` の `app.depends_on` がリスト形式だった
  ため、コンテナの**起動順**しか保証されず、SeaweedFS の S3
  サービスが**準備完了する前**に API が接続を試みていた。

  API 側（`infra/storage.go`）にリトライ処理がないため、接続失
  敗すると即 panic
  し、Air（ホットリロード）がプロセスを管理しているためコンテナ

  ## 対応内容

  `docker-compose.yaml` のみ変更。

  - `seaweedfs` サービスに healthcheck を追加（`curl -sf
  http://localhost:8333/`）
  - `app.depends_on` を `condition: service_healthy`
  形式に変更し、db・seaweedfs の両方が healthy になってから app
  を起動するよう修正

  > **補足:** `wget`（チームで挙がった案）はこのイメージの
  busybox 版では動作しないため、`curl` を採用。

  ## 動作確認

  - `docker compose up -d` 後、手動リスタートなしで `GET
  /fireworks` が `200` を返すことを確認
  - `seaweedfs (healthy)` になった直後に `app`
  が起動する順序を確認
  - API ログに `panic` が出ないことを確認