### PR TITLE
[feat]image2particleの機能を作成し、画像取得のAPIとつなげました。また、解像度調整の機能を作成しました

### DIFF
--- a/user/src/apiClient/schemas/fireworkResponse.ts
+++ b/user/src/apiClient/schemas/fireworkResponse.ts
@@ -6,6 +6,16 @@
  */
 
 /**
+ * 花火を作成するためのリクエストボディ
+ */
+export interface FireworkCreateRequest {
+	/** 花火が共有可能かどうか */
+	isShareable: boolean;
+	/** 花火の元となる画像ファイル */
+	image: Blob;
+}
+
+/**
  * 花火のレスポンスデータ
  */
 export interface FireworkResponse {
@@ -13,10 +23,21 @@ export interface FireworkResponse {
 	id: number;
 	/** 花火が共有可能かどうか */
 	isShareable: boolean;
-	/** 花火のピクセルデータ */
-	pixelData: boolean[];
+	/**
+	 * 元画像の公開URL。旧レコードは null
+	 * （旧フィールド pixelData: boolean[] は廃止）
+	 */
+	imageUrl: string | null;
 	/** 花火の作成日時 */
 	createdAt?: string;
 	/** 花火の更新日時 */
 	updatedAt?: string;
+}
+
+/**
+ * 花火を更新するためのリクエストボディ
+ */
+export interface FireworkUpdateRequest {
+	/** 花火が共有可能かどうか */
+	isShareable: boolean;
 }

--- a/user/src/canvas/HomeCanvas.tsx
+++ b/user/src/canvas/HomeCanvas.tsx
@@ -1,174 +1,142 @@
 import { EffectComposer, Bloom } from '@react-three/postprocessing'
-import { 
+import {
   Suspense,
   useEffect,
   useMemo,
-  forwardRef, 
-  useImperativeHandle, 
+  forwardRef,
+  useImperativeHandle,
   useRef,
 } from 'react'
-import { 
+import {
   Canvas,
   useThree,
 } from '@react-three/fiber'
 import { initializeAR } from '../lib/ar-setup';
 import * as THREE from 'three';
 import HomeScene from '../scenes/HomeScene';
-import type { IllustrationFireworksType } from '../types/illustrationFireworksType';
+import type { IllustrationFireworksType, ColorParticleData } from '../types/illustrationFireworksType';
 import { useDeviceMotionCamera } from './hooks/useDeviceMotionCamera';
 import type { HomeSceneHandle } from '../scenes/HomeScene';
 
 interface HomeCanvasProps {
-  illustrationFireworks: IllustrationFireworksType | null; // イラスト花火のデータ
+  illustrationFireworks: IllustrationFireworksType | null;
+  /** 画像から変換したカラーパーティクルデータ */
+  particleData: ColorParticleData | null;
 }
 
-// コンポーネントの外部から呼び出せる関数を定義
 export type HomeCanvasHandle = {
-  handleLaunch: () => void; // 花火を打ち上げる関数
-  resetCameraRotation: () => void;  // カメラの回転をリセットする関数
-  setCurrentAsInitial: () => void;  // 現在のカメラの回転を初期値として設定する関数
-  setCameraRotation: (euler: THREE.Euler) => void;  // 特定の回転に設定する関数
+  handleLaunch: () => void;
+  resetCameraRotation: () => void;
+  setCurrentAsInitial: () => void;
+  setCameraRotation: (euler: THREE.Euler) => void;
 }
 
-// ===== HomeCanvas =====
-// Three.jsの「土台構成」を行う
-// - カメラ
-// - ライト
-// - レンダラー（マルチレンダーやポストプロセス）
-// - orbit controls などの操作系
-// - MediaPipe連携（Webカメラ映像→Three.jsへ）
-const HomeCanvas = forwardRef<HomeCanvasHandle, HomeCanvasProps>(( props, ref) => {
-  console.log('HomeCanvas rendered');
-  const { illustrationFireworks } = props;
+const HomeCanvas = forwardRef<HomeCanvasHandle, HomeCanvasProps>((props, ref) => {
+  const { illustrationFireworks, particleData } = props;
   const homeSceneRef = useRef<HomeSceneHandle>(null);
   const canvasSetupRef = useRef<CanvasSetupHandle>(null);
 
-  // コンポーネントの外部から呼び出せる関数を定義
   useImperativeHandle(ref, () => ({
     handleLaunch,
     resetCameraRotation,
     setCurrentAsInitial,
     setCameraRotation,
   }));
-  
-  // 花火を打ち上げる関数
+
   const handleLaunch = () => {
-    // HomeSceneの花火を打ち上げる関数を呼び出す
     homeSceneRef.current?.handleLaunch();
   };
 
-  // カメラの回転をリセットする関数
   const resetCameraRotation = () => {
     canvasSetupRef.current?.resetCameraRotation();
   };
 
-  // 現在のカメラの回転を初期値として設定する関数
   const setCurrentAsInitial = () => {
     canvasSetupRef.current?.setCurrentAsInitial();
   };
 
-  // 特定の回転に設定する関数
   const setCameraRotation = (euler: THREE.Euler) => {
     canvasSetupRef.current?.setCameraRotation(euler);
   };
 
   return (
-    <div style={{ position: 'relative', width: '100%', height: '100%' }}>
-      <Canvas 
-        gl={{ alpha: true }}                  // 背景を透明にするためにalphaをtrueに設定
-        style={{ background: 'transparent' }} // 背景を透明に設定
-        // camera={{ position: [0, 0, 30], fov: 50 }} // カメラの初期位置と視野角を設定
-      >
-        <Suspense fallback={null}>
-          <CanvasSetup 
-            ref={canvasSetupRef}
-          />
-          {illustrationFireworks && (
-            <HomeScene
-              illustrationFireworks={illustrationFireworks} // イラスト花火のデータを渡す
-              ref={homeSceneRef} // HomeSceneへの参照を渡す
-            />
-          )}
-        </Suspense>
-      </Canvas>
-    </div>
-  )
+      <div style={{ position: 'relative', width: '100%', height: '100%' }}>
+        <Canvas
+            gl={{ alpha: true }}
+            style={{ background: 'transparent' }}
+        >
+          <Suspense fallback={null}>
+            <CanvasSetup ref={canvasSetupRef} />
+            {/* particleData が揃った時点でシーンをマウント */}
+            {particleData && (
+                <HomeScene
+                    illustrationFireworks={illustrationFireworks}
+                    particleData={particleData}
+                    ref={homeSceneRef}
+                />
+            )}
+          </Suspense>
+        </Canvas>
+      </div>
+  );
 });
 
 export default HomeCanvas;
 
-// コンポーネントの外部から呼び出せる関数を定義
 export type CanvasSetupHandle = {
-  resetCameraRotation: () => void;  // カメラの回転をリセットする関数
-  setCurrentAsInitial: () => void;  // 現在のカメラの回転を初期値として設定する関数
-  setCameraRotation: (euler: THREE.Euler) => void;  // 特定の回転に設定する関数
+  resetCameraRotation: () => void;
+  setCurrentAsInitial: () => void;
+  setCameraRotation: (euler: THREE.Euler) => void;
 }
 
-// Canvasの初期設定(useThreeはcanvas内でのみ使用可能なため切り分けている)
-const CanvasSetup = forwardRef<CanvasSetupHandle>(( _, ref) => {
-  // THREE.Scene, THREE.Camera, THREE.WebGLRendererを取得
+const CanvasSetup = forwardRef<CanvasSetupHandle>((_,  ref) => {
   const { scene, camera, gl } = useThree();
-  
-  // ARの初期化（video要素を受け取る）
+
   const arData = useMemo(() => {
     return initializeAR(scene, camera, gl);
   }, [scene, camera, gl]);
-  const { arToolkitSource, arToolkitContext, markerRoot, videoElement, videoTexture } = arData;
-  
+  const { arToolkitSource } = arData;
+
   console.log('ARToolkitSource:', arToolkitSource);
-  
-  // カメラの位置を設定
+
   useEffect(() => {
     camera.position.set(0, 0, 30);
   }, [camera]);
-  
-  // デバイスの回転を検知してカメラを動かすフックを使用
+
   const { resetCameraRotation, setCurrentAsInitial, setCameraRotation } = useDeviceMotionCamera(0.7);
 
-  // コンポーネントの外部から呼び出せる関数を定義
   useImperativeHandle(ref, () => ({
     resetCameraRotation,
     setCurrentAsInitial,
     setCameraRotation,
   }));
-  
-  // 色空間とトーンマッピングの設定
+
   useEffect(() => {
-    gl.outputColorSpace = THREE.SRGBColorSpace; // 色空間をsRGBに設定
-    gl.toneMapping = THREE.ACESFilmicToneMapping; // トーンマッピングをACESToneMappingに設定(くっきりした色合いになる)
-    gl.toneMappingExposure = 1; // ブルームが映えるように露出を調整(ブルームの強さを調整)
+    gl.outputColorSpace = THREE.SRGBColorSpace;
+    gl.toneMapping = THREE.ACESFilmicToneMapping;
+    gl.toneMappingExposure = 1;
   }, [gl]);
 
   return (
-    <>
-      {/* ポイントライト */}
-      <pointLight
-        position={[10, 10, 10]} // 光源の位置
-        intensity={2}           // 光の強さ
-        distance={50}           // 光の届く距離
-        decay={1}               // 光の減衰率
-        color="white"           // 光の色
-        // castShadow           // 影を落とす
-      />
-      
-      {/* 環境光 */}
-      {/* <ambientLight
-        intensity={10} // 環境光の強さ
-        color="white"  // 環境光の色
-      /> */}
-
-      {/* Unreal Bloom */}
-      <EffectComposer>
-        <Bloom
-          luminanceThreshold={0.2}    // ブルームがかかる明るさの閾値 (調整: 低いほど光る)
-          luminanceSmoothing={0.2}    // ブルームのスムージング(調整: 1.0で滑らか)
-          intensity={0.6}             // bloomの強さ
-          width={window.innerWidth}    // ブルームの幅
-          height={window.innerHeight}  // ブルームの高さ
-          mipmapBlur={true}            // ミップマップを使用してブルームを適用
-          resolutionScale={window.devicePixelRatio > 2 ? 1.0 : 1.5}  // DPR > 2 はパフォーマンス優先
+      <>
+        <pointLight
+            position={[10, 10, 10]}
+            intensity={2}
+            distance={50}
+            decay={1}
+            color="white"
         />
-      </EffectComposer>
-    </>
-  )
+        <EffectComposer>
+          <Bloom
+              luminanceThreshold={0.2}
+              luminanceSmoothing={0.2}
+              intensity={0.6}
+              width={window.innerWidth}
+              height={window.innerHeight}
+              mipmapBlur={true}
+              resolutionScale={window.devicePixelRatio > 2 ? 1.0 : 1.5}
+          />
+        </EffectComposer>
+      </>
+  );
 });

--- a/user/src/components/fireworks/Illustration/Exploding.tsx
+++ b/user/src/components/fireworks/Illustration/Exploding.tsx
@@ -1,179 +1,178 @@
-import { 
-  useRef, 
+import {
+  useRef,
   memo,
   useEffect,
   useState,
-} from 'react'
-import { 
-  useFrame, 
-} from '@react-three/fiber'
-import * as THREE from 'three'
+} from 'react';
+import { useFrame } from '@react-three/fiber';
+import * as THREE from 'three';
+import type { ColorParticleData } from '../../types/illustrationFireworksType';
 
 interface Props {
-  color?: THREE.ColorRepresentation; // 花火の色
-  position?: THREE.Vector3; // 花火の打ち上げの中心位置
-  size?: number; // 花火のサイズ(パーティクルではなくて花弁の大きさ)
-  data: boolean[][] // 花火のイラストデータ(booleanの2次元配列)
-  starSize?: number; // 星のサイズ
-  onComplete?: () => void;  // 花火が終了したときのコールバック
+  position?: THREE.Vector3;
+  /** 絵の表示サイズ（座標空間でのスケール） */
+  size?: number;
+  /** パーティクルの点サイズ */
+  starSize?: number;
+  /** 展開アニメーションの時間（秒） */
+  expandTime?: number;
+  /** 展開後のフェードアウト時間（秒） */
+  fadeTime?: number;
+  /** 画像から変換したカラーパーティクルデータ */
+  particleData: ColorParticleData;
+  onComplete?: () => void;
 }
 
-// イラスト花火
-const IllustrationExploding =  memo(function IllustrationExploding({ 
-  color = 'white', 
-  position = new THREE.Vector3(0, 0, 0), 
-  size = 1, 
-  starSize = 0.2,
-  data,
-  onComplete = () => {}
-}: Props) {
-  // width
-  const width = data[0].length // イラストの横幅
-  // height
-  const height = data.length // イラストの縦幅
-  // 重力の強さ
-  const gravity = 0.005
-  // デフォルトの速度
-  const defaultVelocity = 0.3
-  // 星のオフセット
-  const starOffset = 0.01
-  
-  // 星のパーティクルを描画するための参照
-  const starPointsRef = useRef<THREE.Points>(null)  // ポイントの参照
-  const starPositions = useRef(new Float32Array()) // パーティクルの位置を格納する配列
-  const starVelocities = useRef<THREE.Vector3[]>([]) // パーティクルの速度を格納する配列
-  const initTime = useRef<number | null>(null) // シーンが配置されてからの時間を保持する変数
-  
-  const [isCompleted, setIsCompleted] = useState(false) // 花火の完了状態を管理
-  
-  // マウント時の処理とアンマウント時の処理
+/**
+ * イラスト花火の爆発コンポーネント（カラーパーティクル版）
+ *
+ * フェーズ:
+ *   Phase1 (expandTime): 中心から絵の形へ EaseOut 展開
+ *   Phase2 (fadeTime):   絵の形を維持しながらフェードアウト＋重力落下
+ */
+const IllustrationExploding = memo(function IllustrationExploding({
+                                                                    position = new THREE.Vector3(0, 0, 0),
+                                                                    size = 6,
+                                                                    starSize = 0.15,
+                                                                    expandTime = 0.8,
+                                                                    fadeTime = 1.5,
+                                                                    particleData,
+                                                                    onComplete = () => {},
+                                                                  }: Props) {
+  const { particles } = particleData;
+  const count = particles.length;
+
+  // BufferGeometry の attribute
+  const pointsRef = useRef<THREE.Points>(null);
+  const posAttr = useRef<THREE.BufferAttribute | null>(null);
+  const colAttr = useRef<THREE.BufferAttribute | null>(null);
+
+  // 目標座標（絵の形）
+  const targetPositions = useRef<Float32Array>(new Float32Array(count * 3));
+  // 現在座標
+  const currentPositions = useRef<Float32Array>(new Float32Array(count * 3));
+  // 色
+  const colors = useRef<Float32Array>(new Float32Array(count * 3));
+
+  const initTime = useRef<number | null>(null);
+  const [isCompleted, setIsCompleted] = useState(false);
+
+  // ── 初期化 ──────────────────────────────────────────────────────────────
   useEffect(() => {
-    // ====== マウント時の処理 ======
-    // 星のパーティクル位置と速度の初期化
-    const halfWidth = width / 2
-    const halfHeight = height / 2
-    console.log('position', position)
-    const pos: number[] = []
-    
-    for (let y = 0; y < height; y++) {
-      for (let x = 0; x < width; x++) {
-        // イラストのピクセルがtrueの場合のみパーティクル(星)を生成
-        if (data[y][x]) {
-          // パーティクルの位置を計算
-          const initPos = new THREE.Vector3(
-            (x - halfWidth) * starOffset + position.x,
-            (halfHeight - y) * starOffset + position.y,
-            position.z
-          )
-          
-          // 初期座標
-          pos.push(initPos.x, initPos.y, initPos.z)
+    // 目標座標と色を計算
+    for (let i = 0; i < count; i++) {
+      const p = particles[i];
+      // 正規化座標 (0〜1) → 中心 (0,0) 基準のワールド座標
+      targetPositions.current[i * 3] = (p.x - 0.5) * size + position.x;
+      targetPositions.current[i * 3 + 1] = (p.y - 0.5) * size + position.y;
+      targetPositions.current[i * 3 + 2] = position.z;
 
-          // 星の移動方向を計算
-          const direction = new THREE.Vector3().subVectors(initPos, position)
+      // 初期座標は全て爆発中心
+      currentPositions.current[i * 3] = position.x;
+      currentPositions.current[i * 3 + 1] = position.y;
+      currentPositions.current[i * 3 + 2] = position.z;
 
-          // 速度ベクトル
-          starVelocities.current.push(new THREE.Vector3(
-            direction.x * size,
-            direction.y * size,
-            0 // z軸は固定なので0
-          ).multiplyScalar(defaultVelocity)) // 速度を設定
-        }
-      }
+      // 色（0〜1 に正規化）
+      colors.current[i * 3] = p.r / 255;
+      colors.current[i * 3 + 1] = p.g / 255;
+      colors.current[i * 3 + 2] = p.b / 255;
     }
-    // パーティクルの位置を格納
-    starPositions.current = new Float32Array(pos)
-    
-    // 星のパーティクルのジオメトリを初期化
-    const starGeometry = new THREE.BufferGeometry()
-    starGeometry.setAttribute(
-      'position',
-      new THREE.BufferAttribute(starPositions.current, 3)
-      .setUsage(THREE.DynamicDrawUsage) // 動的に更新するための設定
-    )
-    // ポイントのジオメトリを設定
-    starPointsRef.current!.geometry = starGeometry
-    
-    // ====== アンマウント時の処理 ======
+
+    if (!pointsRef.current) return;
+
+    const geo = new THREE.BufferGeometry();
+
+    const pAttr = new THREE.BufferAttribute(currentPositions.current, 3);
+    pAttr.setUsage(THREE.DynamicDrawUsage);
+    geo.setAttribute('position', pAttr);
+    posAttr.current = pAttr;
+
+    const cAttr = new THREE.BufferAttribute(colors.current, 3);
+    geo.setAttribute('color', cAttr);
+    colAttr.current = cAttr;
+
+    pointsRef.current.geometry = geo;
+
     return () => {
-      // コンポーネントがアンマウントされたときの処理
-      if (starPointsRef.current) {
-        // ジオメトリを解放
-        starPointsRef.current.geometry.dispose()
-        // マテリアルも解放
-        if (Array.isArray(starPointsRef.current.material)) {
-          starPointsRef.current.material.forEach((mat) => mat.dispose())
-        } else {
-          starPointsRef.current.material.dispose()
-        }
+      geo.dispose();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (isCompleted) onComplete();
+  }, [isCompleted, onComplete]);
+
+  // ── フレーム更新 ─────────────────────────────────────────────────────────
+  useFrame(({ clock }) => {
+    if (!pointsRef.current || !posAttr.current) return;
+
+    if (initTime.current === null) initTime.current = clock.getElapsedTime();
+    const elapsed = clock.getElapsedTime() - initTime.current;
+    const totalTime = expandTime + fadeTime;
+
+    if (elapsed > totalTime) {
+      setIsCompleted(true);
+      return;
+    }
+
+    const mat = pointsRef.current.material as THREE.PointsMaterial;
+
+    if (elapsed <= expandTime) {
+      // ── Phase1: 展開（EaseOut）──
+      const t = easeOutCubic(elapsed / expandTime);
+      mat.opacity = 1;
+
+      for (let i = 0; i < count; i++) {
+        currentPositions.current[i * 3] = THREE.MathUtils.lerp(
+            position.x,
+            targetPositions.current[i * 3],
+            t
+        );
+        currentPositions.current[i * 3 + 1] = THREE.MathUtils.lerp(
+            position.y,
+            targetPositions.current[i * 3 + 1],
+            t
+        );
+        currentPositions.current[i * 3 + 2] = position.z;
+      }
+    } else {
+      // ── Phase2: フェードアウト＋落下 ──
+      const ft = (elapsed - expandTime) / fadeTime;
+      mat.opacity = Math.max(0, 1 - ft);
+      const gravity = ft * ft * 2; // 放物線的落下
+
+      for (let i = 0; i < count; i++) {
+        currentPositions.current[i * 3] = targetPositions.current[i * 3];
+        currentPositions.current[i * 3 + 1] =
+            targetPositions.current[i * 3 + 1] - gravity;
+        currentPositions.current[i * 3 + 2] = position.z;
       }
     }
-  }, [])
-  
-  useEffect(() => {
-    // 花火が完了したときの処理
-    if (isCompleted) {
-      onComplete()
-    }
-  }, [isCompleted, onComplete])
 
-  // フレームごとの更新
-  useFrame(({clock}) => {
-    if (!starPointsRef.current) return // 存在しなければ何もしない
-    if (initTime.current === null) initTime.current = clock.getElapsedTime();  // グローバル時間を記録
-    
-    // コンポーネント配置からの経過時間を計算
-    const elapsed = clock.getElapsedTime() - initTime.current;
-    
-    // すでに経過時間規定値を超えたら完了
-    if (elapsed > 4) {
-      setIsCompleted(true) // 花火が完了したとフラグを設定
-      return // 以降の処理は行わない
-    }
-    
-    // 一定時間経ったら透明度や速度を減少していく
-    if (elapsed > 0) {
-      const material = starPointsRef.current.material as THREE.PointsMaterial
-      material.opacity = Math.max(0, material.opacity - 0.005)    // 透明度を減少
-      starVelocities.current.forEach(v => v.multiplyScalar(0.98)) // 速度を減衰
-    }
+    posAttr.current.needsUpdate = true;
+  });
 
-    // 各星のパーティクルの位置を更新
-    for (let i = 0; i < starVelocities.current.length; i++) {
-      // if (!starVelocities.current[i]) continue // 安全性チェック
-
-      // 速度を計算
-      const vx = starVelocities.current[i].x
-      const vy = starVelocities.current[i].y - gravity // 重力を適用
-      // const vz = starVelocities.current[i].z // z軸は固定なので使用しない
-      
-      // 位置を更新
-      starPositions.current[i * 3 + 0] += vx
-      starPositions.current[i * 3 + 1] += vy
-      // starPositions.current[i * 3 + 2] += vz
-    }
-    
-    // 更新を反映
-    const starPosAttr = starPointsRef.current.geometry.attributes.position as THREE.BufferAttribute
-    starPosAttr.needsUpdate = true
-  })
+  if (count === 0) return null;
 
   return (
-    <>
-      <points ref={starPointsRef}>
+      <points ref={pointsRef}>
         <bufferGeometry />
         <pointsMaterial
-          size={starSize}
-          color={color}
-          vertexColors={false}
-          depthWrite={false}  // 深度書き込みを無効化
-          // opacity={starOpacity.current}
-          transparent={true} // 透明度を有効化
-          blending={THREE.AdditiveBlending}
+            size={starSize}
+            vertexColors={true}
+            transparent={true}
+            opacity={1}
+            depthWrite={false}
+            blending={THREE.AdditiveBlending}
+            sizeAttenuation={true}
         />
       </points>
-    </>
-  )
-})
+  );
+});
 
-export default IllustrationExploding
+export default IllustrationExploding;
+
+// ── ユーティリティ ───────────────────────────────────────────────────────────
+function easeOutCubic(t: number): number {
+  return 1 - Math.pow(1 - t, 3);
+}

--- a/user/src/components/fireworks/Illustration/IllustrationFireworks.tsx
+++ b/user/src/components/fireworks/Illustration/IllustrationFireworks.tsx
@@ -1,98 +1,125 @@
-import { 
-  // useRef, 
+import {
   useState,
   memo,
   useEffect,
-} from 'react'
-// import { 
-//   useFrame, 
-// } from '@react-three/fiber'
-import * as THREE from 'three'
-import Launching from '../Launching.tsx' // 打ち上げ時のトレイルを描画するコンポーネント
-import IllustrationExploding from './Exploding.tsx'
+} from 'react';
+import * as THREE from 'three';
+import Launching from '../Launching';
+import IllustrationExploding from './Exploding';
+import type { ColorParticleData } from '../../types/illustrationFireworksType';
 
 interface FireworkProps {
-  color?: THREE.ColorRepresentation; // 花火の色
-  from?: THREE.Vector3 // 花火の打ち上げの始点
-  to?: THREE.Vector3 // 花火の打ち上げの終点
-  size?: number; // 花火のサイズ
-  data: boolean[][] // 花火のイラストデータ(booleanの2次元配列)
-  isSoundEnabled?: boolean // 音の有無
-  starSize?: number; // 星のサイズ
-  onComplete?: () => void;  // 花火が終了したときのコールバック
+  color?: THREE.ColorRepresentation;
+  from?: THREE.Vector3;
+  to?: THREE.Vector3;
+  /** 絵の表示サイズ（座標空間でのスケール） */
+  size?: number;
+  /** パーティクルの点サイズ */
+  starSize?: number;
+  /** 展開アニメーション時間（秒） */
+  expandTime?: number;
+  /** フェードアウト時間（秒） */
+  fadeTime?: number;
+  /** 画像から変換したカラーパーティクルデータ（省略時は既存の boolean[][] を使用） */
+  particleData?: ColorParticleData;
+  /** 後方互換：白黒 boolean[][] データ（particleData が無い場合に使用） */
+  data?: boolean[][];
+  isSoundEnabled?: boolean;
+  onComplete?: () => void;
 }
 
-// 1層のイラスト花火
-const IllustrationFireworks =  memo(function IllustrationFireworks({ 
-  color = 'white', 
-  from = new THREE.Vector3(0, 0, 0),
-  to = new THREE.Vector3(0, 1, 0), // 上方向に打ち上げ
-  size = 1,
-  data,
-  isSoundEnabled = true,
-  starSize = 0.2,
-  onComplete = () => {}
-}: FireworkProps) {
-  // const initTime = useRef<number | null>(null) // シーンが配置されてからの時間を保持する変数
-  
-  const [isLaunching, setIsLaunching] = useState(true) // 打ち上げ中かどうかのフラグ
-  const [isExploding, setIsExploding] = useState(false) // 爆発中かどうかのフラグ
-  const [isCompleted, setIsCompleted] = useState(false) // 花火の完了状態を管理
+/**
+ * イラスト花火コンポーネント
+ *
+ * - `particleData` が渡された場合: 色付きパーティクルで描画（新方式）
+ * - `data` のみの場合: 白黒パーティクルで描画（後方互換）
+ */
+const IllustrationFireworks = memo(function IllustrationFireworks({
+                                                                    color = 'white',
+                                                                    from = new THREE.Vector3(0, 0, 0),
+                                                                    to = new THREE.Vector3(0, 10, 0),
+                                                                    size = 6,
+                                                                    starSize = 0.15,
+                                                                    expandTime = 0.8,
+                                                                    fadeTime = 1.5,
+                                                                    particleData,
+                                                                    data,
+                                                                    isSoundEnabled = true,
+                                                                    onComplete = () => {},
+                                                                  }: FireworkProps) {
+  const [isLaunching, setIsLaunching] = useState(true);
+  const [isExploding, setIsExploding] = useState(false);
+  const [isCompleted, setIsCompleted] = useState(false);
 
-  // マウント時の処理とアンマウント時の処理
-  // useEffect(() => {
-  //   // ====== マウント時の処理 ======
-    
-  //   // ====== アンマウント時の処理 ======
-  // }, [])
-  
-  // 花火が完了したときの処理
   useEffect(() => {
-    if (isCompleted) {
-      onComplete()
-    }
-  }, [isCompleted, onComplete])
+    if (isCompleted) onComplete();
+  }, [isCompleted, onComplete]);
 
-  // フレームごとの更新
-  // useFrame(({clock}) => {
-  //   if (initTime.current === null) initTime.current = clock.getElapsedTime();  // グローバル時間を記録
-    
-  //   // コンポーネント配置からの経過時間を計算
-  //   const elapsed = clock.getElapsedTime() - initTime.current;
-  // })
+  // boolean[][] → ColorParticleData に変換（後方互換）
+  const resolvedParticleData: ColorParticleData | null = particleData
+      ? particleData
+      : data
+          ? booleanToParticleData(data)
+          : null;
+
+  if (!resolvedParticleData) return null;
 
   return (
-    <>
-      {isLaunching && (
-        <Launching
-          from={from}
-          to={to}
-          duration={2} // 打ち上げの時間
-          color={color}
-          onComplete={() => {
-            setIsLaunching(false); // 打ち上げ完了
-            setIsExploding(true); // 爆発フェーズに移行
-            console.log('Firework launching completed!')
-          }}
-          isSoundEnabled={isSoundEnabled}
-        />
-      )}
-      {isExploding && (
-        <IllustrationExploding
-          color={color}
-          position={to}
-          size={size}
-          data={data}
-          starSize={starSize}
-          onComplete={() => {
-            setIsExploding(false); // 爆発完了
-            setIsCompleted(true);  // 花火が完了したとフラグを設定
-            console.log('Firework exploding completed!')
-          }}
-        />
-      )}
-    </>
-  )
-})
+      <>
+        {isLaunching && (
+            <Launching
+                from={from}
+                to={to}
+                duration={2}
+                color={color}
+                isSoundEnabled={isSoundEnabled}
+                onComplete={() => {
+                  setIsLaunching(false);
+                  setIsExploding(true);
+                }}
+            />
+        )}
+        {isExploding && (
+            <IllustrationExploding
+                position={to}
+                size={size}
+                starSize={starSize}
+                expandTime={expandTime}
+                fadeTime={fadeTime}
+                particleData={resolvedParticleData}
+                onComplete={() => {
+                  setIsExploding(false);
+                  setIsCompleted(true);
+                }}
+            />
+        )}
+      </>
+  );
+});
 
-export default IllustrationFireworks
+export default IllustrationFireworks;
+
+// ── 後方互換ヘルパー ─────────────────────────────────────────────────────────
+
+function booleanToParticleData(data: boolean[][]): ColorParticleData {
+  const height = data.length;
+  const width = data[0]?.length ?? 0;
+  const resolution = Math.max(width, height);
+  const particles = [];
+
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      if (data[y][x]) {
+        particles.push({
+          x: x / (width - 1),
+          y: 1 - y / (height - 1), // 上下反転
+          r: 255,
+          g: 255,
+          b: 255,
+        });
+      }
+    }
+  }
+
+  return { particles, resolution };
+}

--- a/user/src/pages/Home.tsx
+++ b/user/src/pages/Home.tsx
@@ -1,16 +1,14 @@
 import { useState } from 'react'
-import { 
+import {
   useSearchParams
 } from 'react-router-dom'
-import { 
+import {
   useEffect,
   useRef,
 } from 'react'
 import type { IllustrationFireworksType } from '../types/illustrationFireworksType';
-import { 
-  loadIllustrationFireworksFromLocalStorage,
-  saveIllustrationFireworksToLocalStorage
-} from '../lib/localstorage';
+import type { ColorParticleData } from '../types/illustrationFireworksType';
+import { imageUrlToParticles } from '../utils/imageToParticles';
 import { useGetFireworkById } from '../apiClient/fireworks/myARProjectAPI';
 import ScanModal from '../components/common/ScanModal';
 import type { HomeCanvasHandle } from '../canvas/HomeCanvas';
@@ -20,216 +18,237 @@ import HomeCanvas from "../canvas/HomeCanvas";
 // ===== Homeのページ =====
 // ページではデータフェッチやローカルストレージの読み書きを行う
 export default function Home() {
-  // イラスト花火のデータを管理する状態
-  const [illustrationFireworks, setIllustrationFireworks] = useState<IllustrationFireworksType | null>(null)
-  // モーダルの開閉状態を管理する状態
-  const [isOpen, setIsOpen] = useState(false)
-  // クエリパラメータを管理する状態
-  const [searchParams, setSearchParams] = useSearchParams()
-  // HomeCanvasへの参照を作成
+  // イラスト花火のメタデータ
+  const [illustrationFireworks, setIllustrationFireworks] = useState<IllustrationFireworksType | null>(null);
+  // 画像から変換したカラーパーティクルデータ
+  const [particleData, setParticleData] = useState<ColorParticleData | null>(null);
+  const [isConverting, setIsConverting] = useState(false);
+
+  /* DEBUG START - 解像度調整UI（削除するときはここから DEBUG END まで消す） */
+  const [resolution, setResolution] = useState(64);
+  const [pendingResolution, setPendingResolution] = useState(64);
+  /* DEBUG END */
+
+  const [isOpen, setIsOpen] = useState(false);
+  const [searchParams, setSearchParams] = useSearchParams();
   const homeCanvasRef = useRef<HomeCanvasHandle>(null);
 
-  // URLパラメータからIDを取得
-  const currentId = searchParams.get('id') || '1'
-  const validId = !isNaN(Number(currentId)) ? currentId : '1' // idが数値でない場合は1にフォールバック
-  console.log('ID from URL:', validId)
-  
-  // APIから花火データを取得（条件付きで有効化）
+  const currentId = searchParams.get('id') || '1';
+  const validId = !isNaN(Number(currentId)) ? currentId : '1';
+
   const { data, isLoading, error } = useGetFireworkById(Number(validId), {
     query: {
       enabled: Boolean(validId) && !isNaN(Number(validId)) && Number(validId) > 0,
-      staleTime: 5 * 60 * 1000, // 5分間キャッシュ
-      gcTime: 10 * 60 * 1000, // 10分間メモリに保持
+      staleTime: 5 * 60 * 1000,
+      gcTime: 10 * 60 * 1000,
       retry: (failureCount, error) => {
-        // AbortErrorの場合はリトライしない
-        if (error && typeof error === 'object' && 'name' in error && (error as { name?: string }).name === 'AbortError') return false
-        return failureCount < 1
+        if (error && typeof error === 'object' && 'name' in error && (error as { name?: string }).name === 'AbortError') return false;
+        return failureCount < 1;
       },
       refetchOnWindowFocus: false,
       refetchOnMount: false,
       refetchOnReconnect: false,
     },
-  })
-  
-  
-  // QRコードスキャン時のコールバック関数
+  });
+
   const onScan = (result: string) => {
-    let id = result.match(/id=(\d+)/)?.[1] ?? null; // 正規表現でIDを抽出
+    const id = result.match(/id=(\d+)/)?.[1] ?? null;
     if (id) {
-      console.log('QR Code ID:', id);
-      // URLのクエリパラメータを更新
       searchParams.set('id', id);
       setSearchParams(searchParams);
-      setIsOpen(false); // モーダルを閉じる
+      setIsOpen(false);
     }
-  }
-  
-  
-  // ローカルストレージのチェック（IDが変更された時のみ）
-  useEffect(() => {
-    if (!validId) return  // 有効なIDがない場合は何もしない
-    console.log('Checking localStorage for ID:', validId)
-    
-    // ローカルストレージからデータを取得
-    const storedData = loadIllustrationFireworksFromLocalStorage(validId)
-    if (storedData) {
-      // データが存在する場合は状態にセット
-      setIllustrationFireworks(storedData)
-      console.log('✅ Loaded from localStorage:', storedData)
-    } else {
-      // ローカルストレージにデータがない場合、illustrationFireworksをnullにしてAPIデータの取得を待つ
-      console.log('⚠️ No data in localStorage for ID:', validId)
-      setIllustrationFireworks(null)
-    }
-  }, [validId]) // validIdが変更された時のみ実行
-  
-  // APIデータの処理
-  useEffect(() => {
-    if (!data) return // 既にデータがある場合はスキップ
-    
-    // 既にローカルストレージにデータがある場合はスキップ
-    if (illustrationFireworks && illustrationFireworks.id === data.id) {
-      console.log('⏭️ Skip API data processing - already have data')
-      return
-    }
-    
-    console.log('Fireworks Data:', data)
-    
-    try {
-      const width = Math.sqrt(data.pixelData.length)  // ピクセルデータの幅を計算
-      // pixelData(boolean[])をboolean[][]に変換
-      const fetchedPixelData = data.pixelData.reduce((acc: boolean[][], val: boolean, index: number) => {
-        const rowIndex = Math.floor(index / width)  // 行のインデックスを計算
-        if (!acc[rowIndex]) {
-          acc[rowIndex] = []  // 行がまだ存在しない場合は初期化
-        }
-        acc[rowIndex].push(val)
-        return acc
-      }, [])
-      
-      // 変換したデータを状態にセット
-      setIllustrationFireworks({
-        ...data,
-        pixelData: fetchedPixelData
-      })
-      
-      // ローカルストレージに保存
-      saveIllustrationFireworksToLocalStorage({
-        ...data,
-        pixelData: fetchedPixelData
-      })
-    } catch (error) {
-      console.error('Error processing pixelData:', error)
-      setIllustrationFireworks(null) // エラー時はnullに設定
-    }
-  }, [data])
-  
-  // エラーハンドリング
-  useEffect(() => {
-    if (isLoading) {
-      console.log('Loading fireworks data...')
-    } else if (error) {
-      console.error('Error fetching fireworks data:', error)
-    }
-  }, [isLoading, error])
+  };
 
-  // 花火を打ち上げる関数
+  // IDが変わったらパーティクルデータをリセット
+  useEffect(() => {
+    setParticleData(null);
+    setIllustrationFireworks(null);
+  }, [validId]);
+
+  // APIデータ取得後の処理（resolution 変更時も再変換）
+  useEffect(() => {
+    if (!data) return;
+
+    const meta: IllustrationFireworksType = {
+      id: data.id,
+      isShareable: data.isShareable,
+      imageUrl: data.imageUrl ?? null,
+      createdAt: data.createdAt?.toString(),
+      updatedAt: data.updatedAt?.toString(),
+    };
+    setIllustrationFireworks(meta);
+
+    if (!data.imageUrl) {
+      console.warn('imageUrl が null です（旧レコード）');
+      return;
+    }
+
+    // 画像 → カラーパーティクル変換
+    setIsConverting(true);
+    imageUrlToParticles(data.imageUrl, {
+      resolution, /* DEBUG - 固定値に戻す場合は resolution を 64 などに変更 */
+      whiteThreshold: 200,
+      saturationThreshold: 30,
+      includeWhite: false,
+    })
+        .then((pd) => {
+          setParticleData(pd);
+          console.log(`パーティクル変換完了: ${pd.particles.length} 粒子`);
+        })
+        .catch((err) => {
+          console.error('パーティクル変換失敗:', err);
+        })
+        .finally(() => {
+          setIsConverting(false);
+        });
+  }, [data, resolution]);
+
+  useEffect(() => {
+    if (isLoading) console.log('Loading fireworks data...');
+    else if (error) console.error('Error fetching fireworks data:', error);
+  }, [isLoading, error]);
+
   const handleLaunch = () => {
     homeCanvasRef.current?.handleLaunch();
     resetCameraRotation();
   };
-  
-  // カメラの回転をリセットする関数
-    const resetCameraRotation = () => {
-      homeCanvasRef.current?.resetCameraRotation();
-    };
-  
-    // // 現在のカメラの回転を初期値として設定する関数
-    // const setCurrentAsInitial = () => {
-    //   homeCanvasRef.current?.setCurrentAsInitial();
-    // };
-  
-    // // 特定の回転に設定する関数
-    // const setCameraRotation = (euler: THREE.Euler) => {
-    //   homeCanvasRef.current?.setCameraRotation(euler);
-    // };
-    
+
+  const resetCameraRotation = () => {
+    homeCanvasRef.current?.resetCameraRotation();
+  };
+
   const buttonStyle: React.CSSProperties = {
     width: '200px',
     padding: '4px 8px',
     fontSize: '16px',
     cursor: 'pointer',
-    // marginTop: '20px',
     position: 'absolute',
-    // bottom: '20px',
     left: '50%',
-    transform: 'translateX(-50%)',  // 水平方向中央配置
-    // zIndex: 500,
+    transform: 'translateX(-50%)',
   };
 
+  const isReady = !!particleData && !isConverting;
+
   return (
-    <div style={{ width: '100vw', height: '100vh', overflow: 'hidden' }}>
-      {/* イラスト花火のデータが読み込まれた場合はHomeCanvasを表示 */}
-      <HomeCanvas
-        illustrationFireworks={illustrationFireworks} // イラスト花火のデータを渡す
-        ref={homeCanvasRef} // HomeCanvasへの参照を渡す
-      />
-      <button
-        onClick={() => setIsOpen(true)} // モーダルを開く
-        style={{
-          ...buttonStyle,
-          bottom: '20px',
-        }}
-      >
-        QRコードをスキャン
-      </button>
-      {illustrationFireworks?
-        <>
-          <button
-            onClick={() => handleLaunch()} // 花火を打ち上げる
-            style={{
+      <div style={{ width: '100vw', height: '100vh', overflow: 'hidden' }}>
+        <HomeCanvas
+            illustrationFireworks={illustrationFireworks}
+            particleData={particleData}
+            ref={homeCanvasRef}
+        />
+
+        <button
+            onClick={() => setIsOpen(true)}
+            style={{ ...buttonStyle, bottom: '20px' }}
+        >
+          QRコードをスキャン
+        </button>
+
+        {isLoading || isConverting ? (
+            <div style={{
               ...buttonStyle,
-              backgroundColor: '#f0b810ff',
-              bottom: '120px',
-            }}
-          >
-            花火を打ち上げる
-          </button>
-          <button
-            onClick={() => resetCameraRotation()} // カメラの回転をリセットする
-            style={{
-              ...buttonStyle,
-              // backgroundColor: '#4b4b4bff',
-              // color: 'white',
-              bottom: '60px',
-            }}
-          >
-            カメラのリセット
-          </button>
-        </>
-        : <div 
-          style={{
-            backgroundColor: 'rgba(255, 255, 255, 0.6)',
-            width: 'auto',
-            padding: '4px 8px',
-            fontSize: '16px',
-            cursor: 'pointer',
-            // marginTop: '20px',
-            position: 'absolute',
-            bottom: '80px',
-            left: '50%',
-            transform: 'translateX(-50%)',  // 水平方向中央配置
-            // zIndex: 500,
-          }}>
-          花火が読み込めませんでした<br />
-          別のQRコードをスキャンしてください
+              bottom: '80px',
+              backgroundColor: 'rgba(255,255,255,0.6)',
+              textAlign: 'center',
+            }}>
+              {isLoading ? '読み込み中...' : '画像を変換中...'}
+            </div>
+        ) : isReady ? (
+            <>
+              <button
+                  onClick={handleLaunch}
+                  style={{
+                    ...buttonStyle,
+                    backgroundColor: '#f0b810ff',
+                    bottom: '120px',
+                  }}
+              >
+                花火を打ち上げる
+              </button>
+              <button
+                  onClick={resetCameraRotation}
+                  style={{ ...buttonStyle, bottom: '60px' }}
+              >
+                カメラのリセット
+              </button>
+            </>
+        ) : (
+            <div style={{
+              backgroundColor: 'rgba(255, 255, 255, 0.6)',
+              width: 'auto',
+              padding: '4px 8px',
+              fontSize: '16px',
+              position: 'absolute',
+              bottom: '80px',
+              left: '50%',
+              transform: 'translateX(-50%)',
+            }}>
+              花火が読み込めませんでした<br />
+              別のQRコードをスキャンしてください
+            </div>
+        )}
+
+        <ScanModal
+            isOpen={isOpen}
+            onScan={onScan}
+            closeModal={() => setIsOpen(false)}
+        />
+
+        {/* DEBUG START - 解像度調整パネル（削除するときはここから DEBUG END まで消す） */}
+        <div style={{
+          position: 'absolute',
+          top: '12px',
+          left: '12px',
+          backgroundColor: 'rgba(0,0,0,0.65)',
+          color: 'white',
+          padding: '10px 14px',
+          borderRadius: '8px',
+          fontSize: '13px',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '6px',
+          zIndex: 1000,
+        }}>
+          <div style={{ fontWeight: 'bold' }}>🔧 解像度調整（DEBUG）</div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <span>16</span>
+            <input
+                type="range"
+                min={16}
+                max={512}
+                step={16}
+                value={pendingResolution}
+                onChange={(e) => setPendingResolution(Number(e.target.value))}
+                style={{ width: '120px' }}
+            />
+            <span>512</span>
+          </div>
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '8px' }}>
+            <span>選択中: <strong>{pendingResolution}×{pendingResolution}</strong></span>
+            <button
+                onClick={() => setResolution(pendingResolution)}
+                disabled={isConverting}
+                style={{
+                  padding: '2px 10px',
+                  fontSize: '12px',
+                  cursor: isConverting ? 'not-allowed' : 'pointer',
+                  borderRadius: '4px',
+                  border: 'none',
+                  backgroundColor: '#f0b810',
+                  fontWeight: 'bold',
+                }}
+            >
+              {isConverting ? '変換中...' : '適用'}
+            </button>
+          </div>
+          {particleData && (
+              <div style={{ fontSize: '11px', opacity: 0.8 }}>
+                現在: {resolution}×{resolution} / {particleData.particles.length} 粒子
+              </div>
+          )}
         </div>
-      }
-      <ScanModal
-        isOpen={isOpen} // モーダルの開閉状態を渡す
-        onScan={onScan} // QRコードスキャン時のコールバック関数を渡す
-        closeModal={() => setIsOpen(false)} // モーダルを閉じる関数を渡す
-      />
-    </div>
+        {/* DEBUG END */}
+      </div>
   );
 }

--- a/user/src/scenes/HomeScene.tsx
+++ b/user/src/scenes/HomeScene.tsx
@@ -1,78 +1,64 @@
-import { 
-  useState, 
-  forwardRef, 
-  useImperativeHandle, 
-} from 'react'
+import {
+  useState,
+  forwardRef,
+  useImperativeHandle,
+} from 'react';
 import * as THREE from 'three';
-// import HtmlButton from '../components/common/HtmlButton';
 import IllustrationFireworks from '../components/fireworks/Illustration/IllustrationFireworks';
-import type { IllustrationFireworksType } from '../types/illustrationFireworksType';
+import type { IllustrationFireworksType, ColorParticleData } from '../types/illustrationFireworksType';
 
 interface HomeSceneProps {
-  illustrationFireworks: IllustrationFireworksType; // イラスト花火のデータ
+  illustrationFireworks: IllustrationFireworksType | null;
+  /** 画像から変換したカラーパーティクルデータ */
+  particleData: ColorParticleData | null;
 }
 
-// コンポーネントの外部から呼び出せる関数を定義
 export type HomeSceneHandle = {
-  handleLaunch: () => void; // 花火を打ち上げる関数
-}
+  handleLaunch: () => void;
+};
 
-// ===== HomeSceneコンポーネント =====
-// Three.js空間の「中身（オブジェクト）」を構成する
-// HTMLボタンはpageに置くべきだが、面倒なのでここに置く
-const HomeScene = forwardRef<HomeSceneHandle, HomeSceneProps>(( props, ref) => {
-  const {illustrationFireworks} = props;
-  const explodingHeight = 10;     // 花火の打ち上げ高さ
-  const explosionRadius = 1;      // 花火の爆発半径
-  
-  // 花火の打ち上げ位置を管理する状態(この配列の長さ分、花火が打ち上がる)
-  const [fireworks, setFireworks] = useState<{ id: string; position: THREE.Vector3; color?: THREE.Color }[]>([])
-  console.log('Fireworks:', fireworks)
-  
-  // コンポーネントの外部から呼び出せる関数を定義
-  useImperativeHandle(ref, () => ({
-    handleLaunch,
-  }));
-  
-  // ボタンをクリックしたときに花火を発射する関数
+const HomeScene = forwardRef<HomeSceneHandle, HomeSceneProps>((props, ref) => {
+  const { particleData } = props;
+  const explodingHeight = 10;
+
+  const [fireworks, setFireworks] = useState<{ id: string; position: THREE.Vector3; color?: THREE.Color }[]>([]);
+
+  useImperativeHandle(ref, () => ({ handleLaunch }));
+
   const handleLaunch = () => {
-    // 一意のIDを生成
-    const id = crypto.randomUUID()
-    // ランダムな色を生成
+    if (!particleData) return;
+    const id = crypto.randomUUID();
     const color = new THREE.Color(`hsl(${Math.random() * 360}, 100%, 50%)`);
-    // 花火の打ち上げ位置をランダムに決定
     const position = new THREE.Vector3(
-      (Math.random() - 0.5) * 10,
-      -10,
-      (Math.random() - 0.5) * 10
-    )
-    // 花火の打ち上げ座標を配列に格納(この配列の長さ分、花火が打ち上がる)
-    setFireworks((prev) => [...prev, { id, position, color }])
-  }
-  
-  // 花火が終了したときの処理
+        (Math.random() - 0.5) * 10,
+        -10,
+        (Math.random() - 0.5) * 10
+    );
+    setFireworks((prev) => [...prev, { id, position, color }]);
+  };
+
   const onFinished = (id: string) => {
-    // 終了した花火を配列から削除
-    setFireworks((prev) => prev.filter(fw => fw.id !== id))
-    console.log('Firework finished:', id)
-  }
-  
+    setFireworks((prev) => prev.filter((fw) => fw.id !== id));
+  };
+
+  if (!particleData) return null;
+
   return (
-    <>
-      {fireworks.map((fw) => (
-        <IllustrationFireworks
-          key={fw.id}
-          from={fw.position}  // 花火の打ち上げの始点
-          to={new THREE.Vector3(fw.position.x, fw.position.y + explodingHeight, fw.position.z)} // 花火の打ち上げの終点
-          color={fw.color}        // 花火の色を指定
-          size={explosionRadius}        // 花火のサイズを指定
-          data={illustrationFireworks.pixelData}  // 花火のデータを指定
-          onComplete={() => onFinished(fw.id)}    // 花火が終了したときのコールバック
-        />
-      ))}
-      {/* <HtmlButton onClick={handleLaunch} /> */}
-    </>
-  )
+      <>
+        {fireworks.map((fw) => (
+            <IllustrationFireworks
+                key={fw.id}
+                from={fw.position}
+                to={new THREE.Vector3(fw.position.x, fw.position.y + explodingHeight, fw.position.z)}
+                color={fw.color}
+                size={6}
+                starSize={0.15}
+                particleData={particleData}
+                onComplete={() => onFinished(fw.id)}
+            />
+        ))}
+      </>
+  );
 });
 
 export default HomeScene;

--- a/user/src/types/illustrationFireworksType.ts
+++ b/user/src/types/illustrationFireworksType.ts
@@ -2,7 +2,24 @@
 export interface IllustrationFireworksType {
   id: number;
   isShareable: boolean;
-  pixelData: boolean[][];
+  imageUrl: string | null;
   createdAt?: string;
   updatedAt?: string;
+}
+
+// カラーパーティクルの1点
+export interface ColorParticle {
+  // 正規化座標 (0〜1)
+  x: number;
+  y: number;
+  // RGB (0〜255)
+  r: number;
+  g: number;
+  b: number;
+}
+
+// 画像から変換したパーティクルデータ
+export interface ColorParticleData {
+  particles: ColorParticle[];
+  resolution: number; // グリッドの一辺のピクセル数
 }

--- a/user/src/utils/imageToParticles.ts
+++ b/user/src/utils/imageToParticles.ts
@@ -1,0 +1,136 @@
+import type { ColorParticle, ColorParticleData } from '../types/illustrationFireworksType';
+
+export interface ImageToParticlesOptions {
+    /** リサイズ後の一辺のピクセル数（デフォルト: 64） */
+    resolution?: number;
+    /** 白とみなすRGBしきい値 0〜255（デフォルト: 200） */
+    whiteThreshold?: number;
+    /** 彩度しきい値 max-min（デフォルト: 30）これ未満はノイズとして除外 */
+    saturationThreshold?: number;
+    /** 白ピクセルも半透明粒子として含める（デフォルト: false） */
+    includeWhite?: boolean;
+}
+
+/**
+ * 画像URLをn×nグリッドにリサイズし、色ピクセルをColorParticle[]に変換する。
+ * Unityの ImageToParticles.cs と同等のロジック。
+ *
+ * NOTE: Canvas APIを使うため、ブラウザ環境でのみ動作する。
+ * CORS制約により imageUrl は同一オリジンか CORSヘッダ付きである必要がある。
+ */
+export async function imageUrlToParticles(
+    imageUrl: string,
+    options: ImageToParticlesOptions = {}
+): Promise<ColorParticleData> {
+    const {
+        resolution = 64,
+        whiteThreshold = 200,
+        saturationThreshold = 30,
+        includeWhite = false,
+    } = options;
+
+    const pixels = await fetchResizedPixels(imageUrl, resolution);
+    const particles = extractParticles(pixels, resolution, {
+        whiteThreshold,
+        saturationThreshold,
+        includeWhite,
+    });
+
+    console.log(
+        `[imageToParticles] ${resolution}×${resolution} → ${particles.length} particles`
+    );
+
+    return { particles, resolution };
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// 内部実装
+// ────────────────────────────────────────────────────────────────────────────
+
+/** 画像をn×nにリサイズしてRGBAピクセル配列を返す */
+async function fetchResizedPixels(
+    url: string,
+    n: number
+): Promise<Uint8ClampedArray> {
+    return new Promise((resolve, reject) => {
+        const img = new Image();
+        img.crossOrigin = 'anonymous';
+
+        img.onload = () => {
+            const canvas = document.createElement('canvas');
+            canvas.width = n;
+            canvas.height = n;
+            const ctx = canvas.getContext('2d');
+            if (!ctx) {
+                reject(new Error('Failed to get 2D canvas context'));
+                return;
+            }
+            ctx.drawImage(img, 0, 0, n, n);
+            const imageData = ctx.getImageData(0, 0, n, n);
+            resolve(imageData.data);
+        };
+
+        img.onerror = () => {
+            reject(new Error(`Failed to load image: ${url}`));
+        };
+
+        img.src = url;
+    });
+}
+
+interface FilterOptions {
+    whiteThreshold: number;
+    saturationThreshold: number;
+    includeWhite: boolean;
+}
+
+/** RGBAピクセル配列からColorParticle[]を抽出する */
+function extractParticles(
+    data: Uint8ClampedArray,
+    n: number,
+    opts: FilterOptions
+): ColorParticle[] {
+    const { whiteThreshold, saturationThreshold, includeWhite } = opts;
+    const particles: ColorParticle[] = [];
+
+    for (let py = 0; py < n; py++) {
+        for (let px = 0; px < n; px++) {
+            // Canvasのピクセルは左上原点・行優先
+            const idx = (py * n + px) * 4;
+            const r = data[idx];
+            const g = data[idx + 1];
+            const b = data[idx + 2];
+            // alpha は使用しない（背景が透明な場合も色として扱う）
+
+            const isWhite =
+                r > whiteThreshold && g > whiteThreshold && b > whiteThreshold;
+
+            const sat = Math.max(r, g, b) - Math.min(r, g, b);
+
+            if (isWhite) {
+                if (includeWhite) {
+                    particles.push({
+                        // y は上が 0 → Three.js では上が正なので反転
+                        x: px / (n - 1),
+                        y: 1 - py / (n - 1),
+                        r: 255,
+                        g: 255,
+                        b: 255,
+                    });
+                }
+            } else {
+                if (sat >= saturationThreshold) {
+                    particles.push({
+                        x: px / (n - 1),
+                        y: 1 - py / (n - 1),
+                        r,
+                        g,
+                        b,
+                    });
+                }
+            }
+        }
+    }
+
+    return particles;
+}


### PR DESCRIPTION
## 概要

Unity版で実装した「画像をカラーパーティクルに変換して花火として打ち上げる」機能をWeb（React Three Fiber）側にも移植した。API側の `FireworkResponse` が `pixelData: boolean[]` から `imageUrl: string | null` に変更されたのに合わせ、フロント側で画像から直接カラーパーティクルを生成する処理を追加。あわせて動作確認用の解像度調整UIも追加した（テスト用のため削除しやすい形で実装）。

## 変更内容

### API対応

- `FireworkResponse` 型定義を更新（`pixelData` 廃止 → `imageUrl: string | null` 追加）
- `IllustrationFireworksType` を `imageUrl` ベースに変更し、`ColorParticle` / `ColorParticleData` 型を新規追加

### 画像→カラーパーティクル変換

- `imageToParticles.ts` （新規）
  - Canvas APIで画像URLを n×n グリッドにリサイズ
  - 白背景除去と彩度しきい値でノイズ除去
  - Unity版 `ImageToParticles.cs` と同等のロジック

### 花火描画の変更

- `IllustrationExploding.tsx`
  - `boolean[][]` の代わりに `ColorParticleData`（位置＋色）を受け取るように変更
  - 展開フェーズ（EaseOut）を追加し、中心から絵の形に広がるように変更
  - 展開後はフェードアウト＋重力落下
- `IllustrationFireworks.tsx`
  - `particleData` propsを追加（新方式）
  - `data: boolean[][]` も引き続きサポート（後方互換）

### 画面側の配線

- `Home.tsx` / `HomeScene.tsx` / `HomeCanvas.tsx`
  - APIから取得した `imageUrl` を `imageUrlToParticles()` で変換し、`particleData` としてシーンまで受け渡し
  - 変換中は「画像を変換中...」表示、未取得時はQRスキャンを促す表示

### デバッグ用解像度調整UI（一時実装）

- `Home.tsx` に `/* DEBUG START */` 〜 `/* DEBUG END */` で囲った區間を追加
  - 16〜128を 16刻みで調整できるスライダーを画面左上に表示
  - 「適用」ボタンで明示的に再変換（スライダー操作中は変換しない）
  - **削除する際は `DEBUG START`/`DEBUG END` 間のコードと、`useEffect` 依存配列の `resolution` を除くだけで復元可能**

## 動作フロー

```
QRスキャン → ID取得 → GET /fireworks/:id
        ↓
imageUrl を取得
        ↓
imageUrlToParticles(imageUrl, { resolution, ... })
        ↓
ColorParticleData （位置＋色の配列）
        ↓
HomeScene → IllustrationFireworks → IllustrationExploding
  Phase1: 展開（EaseOut）
  Phase2: フェードアウト＋重力落下
```

## 注意点

- `imageUrlToParticles` は Canvas API を使用しているため、SeaweedFS側で **CORSヘッダ**（`Access-Control-Allow-Origin`）が設定されていないと画像読み込みが失敗する
- 旧レコード（`imageUrl: null`）の場合は変換をスキップし、「花火が読み込めませんでした」表示にフォールバック

## 今後の対応（未実装）

- 解像度調整UIを本番仕様として残すかどうかの検討
- 白ピクセルも含めるオプション（`includeWhite`）のUI化