### PR TITLE
花火を選択した際の画像プレビューを表示するコンポーネントの追加のプルリクの残骸

### DIFF
--- a/admin/components/QRCode.tsx
+++ b/admin/components/QRCode.tsx
@@ -3,11 +3,13 @@
 import { FC, useRef, useCallback, useState } from "react";
 import Image from "next/image";
 import QRCodeButtons from "./QRCodeButtons";
+import ImagePreview from "./admin/ImagePreview";
 
 interface QRCodeProps {
     url: string;
     size?: number;
     fireworkId: number;
+    imageUrl: string | null;
     originalImageFile?: File;
     onDownload?: (canvas: HTMLCanvasElement) => void;
     onError?: (error: string) => void;
@@ -17,6 +19,7 @@ const QRCodeComponent: FC<QRCodeProps> = ({
                                               url,
                                               size = 250,
                                               fireworkId,
+                                              imageUrl,
                                               originalImageFile,
                                               onDownload,
                                               onError
@@ -421,54 +424,59 @@ const QRCodeComponent: FC<QRCodeProps> = ({
 
     return (
         <div style={{ textAlign: 'center' }}>
-            <div
-                style={{
-                    display: 'inline-block',
-                    padding: '1.5rem',
-                    backgroundColor: 'white',
-                    border: '2px solid #e2e8f0',
-                    borderRadius: '12px',
-                    marginBottom: '1.5rem',
-                    boxShadow: '0 4px 6px rgba(0, 0, 0, 0.07)',
-                }}
-            >
-                {imageError ? (
-                    <div
-                        style={{
-                            width: size,
-                            height: size,
-                            display: 'flex',
-                            alignItems: 'center',
-                            justifyContent: 'center',
-                            backgroundColor: '#fed7d7',
-                            color: '#c53030',
-                            border: '2px solid #feb2b2',
-                            borderRadius: '8px',
-                            fontSize: '0.875rem',
-                            fontWeight: '600'
-                        }}
-                    >
-                        ❌ QR Code failed to load
-                    </div>
-                ) : (
-                    <Image
-                        ref={imgRef}
-                        src={qrImageUrl}
-                        alt="QR Code"
-                        width={size}
-                        height={size}
-                        style={{
-                            display: 'block',
-                            borderRadius: '8px',
-                            border: '1px solid #e2e8f0'
-                        }}
-                        onError={handleImageError}
-                        onLoad={handleImageLoad}
-                        unoptimized={true}
-                    />
-                )}
+            <div className="saa" style={{ display: 'flex', justifyContent: 'center'}}>
+                <ImagePreview 
+                imageUrl={imageUrl}
+                />
+                <div
+                    style={{
+                        display: 'inline-block',
+                        padding: '1.5rem',
+                        backgroundColor: 'white',
+                        border: '2px solid #e2e8f0',
+                        borderRadius: '12px',
+                        marginBottom: '1.5rem',
+                        boxShadow: '0 4px 6px rgba(0, 0, 0, 0.07)',
+                    }}
+                >
+                    {imageError ? (
+                        <div
+                            style={{
+                                width: size,
+                                height: size,
+                                display: 'flex',
+                                alignItems: 'center',
+                                justifyContent: 'center',
+                                backgroundColor: '#fed7d7',
+                                color: '#c53030',
+                                border: '2px solid #feb2b2',
+                                borderRadius: '8px',
+                                fontSize: '0.875rem',
+                                fontWeight: '600'
+                            }}
+                        >
+                            ❌ QR Code failed to load
+                        </div>
+                    ) : (
+                        <Image
+                            ref={imgRef}
+                            src={qrImageUrl}
+                            alt="QR Code"
+                            width={size}
+                            height={size}
+                            style={{
+                                display: 'block',
+                                borderRadius: '8px',
+                                border: '1px solid #e2e8f0'
+                            }}
+                            onError={handleImageError}
+                            onLoad={handleImageLoad}
+                            unoptimized={true}
+                        />
+                    )}
+                </div>
             </div>
-
+            
             <QRCodeButtons
                 onDownload={onDownload ? handleDownload : undefined}
                 onGeneratePrint={handleGeneratePrintPage}

--- a/admin/components/admin/ImagePreview.tsx
+++ b/admin/components/admin/ImagePreview.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import Image from "next/image";
+import { useState } from "react";
+
+interface ImagePreviewProps {
+  imageUrl?: string | null;
+}
+
+export default function ImagePreview({
+  imageUrl,
+}: ImagePreviewProps) {
+  const [hasError, setHasError] = useState(false);
+
+  if (!imageUrl || hasError) {
+    return (
+      <div
+        style={{
+          width: 200,
+          height: 200,
+          padding: "1.5rem",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          backgroundColor: "#f7fafc",
+          border: "2px solid #e2e8f0",
+          borderRadius: "12px",
+          color: "#718096",
+          boxSizing: "content-box",
+        }}
+      >
+        {hasError ? "画像の読み込みに失敗しました" : "画像がありません"}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      style={{
+        width: 200,
+        height: 200,
+        padding: "1.5rem",
+        backgroundColor: "white",
+        border: "2px solid #e2e8f0",
+        borderRadius: "12px",
+        boxShadow: "0 4px 6px rgba(0, 0, 0, 0.07)",
+        boxSizing: "content-box",
+      }}
+    >
+      <Image
+        src={imageUrl}
+        alt="花火画像のプレビュー"
+        width={200}
+        height={200}
+        unoptimized
+        onError={() => setHasError(true)}
+        style={{
+          width: "100%",
+          height: "100%",
+          objectFit: "contain",
+          display: "block",
+          borderRadius: "8px",
+        }}
+      />
+    </div>
+  );
+}

--- a/admin/components/admin/QRCodePanel.tsx
+++ b/admin/components/admin/QRCodePanel.tsx
@@ -33,6 +33,7 @@ export default function QRCodePanel({
           url={qrUrl}
           size={200}
           fireworkId={firework.id}
+          imageUrl={firework.imageUrl}
           originalImageFile={originalImageFile}
           onDownload={onDownload}
           onError={onError}

--- a/admin/hooks/useFireworks.ts
+++ b/admin/hooks/useFireworks.ts
@@ -3,6 +3,7 @@ import { useState, useEffect, useCallback } from 'react';
 export interface Firework {
   id: number;
   isShareable: boolean;
+  imageUrl: string | null;
   pixelData: boolean[];
   createdAt?: string;
   updatedAt?: string;


### PR DESCRIPTION
花火を選択した際の画像プレビューを表示するコンポーネントを追加した。

↓画像のように、選択した花火に応じて、preview画像が表示されるようにした。

<img width="1728" height="775" alt="image" src="https://github.com/user-attachments/assets/b7cadd7a-bd48-4cb6-8524-e42c96e332a9" />
<img width="1761" height="763" alt="image" src="https://github.com/user-attachments/assets/68d1bd12-ae20-49d1-bc75-5826b1696119" />

確認事項
- [ ] 動作に問題ないか
- [ ] 表示の大きさ等は適切か
- [ ] 画像の取得方法に問題はないか