### PR TITLE
[feat]花火を選択した際の画像プレビューを表示するコンポーネントの追加

### DIFF
--- a/admin/components/QRCode.tsx
+++ b/admin/components/QRCode.tsx
@@ -3,12 +3,14 @@
 import { FC, useRef, useCallback, useState } from "react";
 import Image from "next/image";
 import QRCodeButtons from "./QRCodeButtons";
+import ImagePreview from "./admin/ImagePreview";
 
 interface QRCodeProps {
     url: string;
     size?: number;
     fireworkId: number;
     originalImageFile?: File;
+    imageUrl: string | null;
     onDownload?: (canvas: HTMLCanvasElement) => void;
     onError?: (error: string) => void;
 }
@@ -17,6 +19,7 @@ const QRCodeComponent: FC<QRCodeProps> = ({
                                               url,
                                               size = 250,
                                               fireworkId,
+                                              imageUrl,
                                               originalImageFile,
                                               onDownload,
                                               onError
@@ -421,52 +424,57 @@ const QRCodeComponent: FC<QRCodeProps> = ({
 
     return (
         <div style={{ textAlign: 'center' }}>
-            <div
-                style={{
-                    display: 'inline-block',
-                    padding: '1.5rem',
-                    backgroundColor: 'white',
-                    border: '2px solid #e2e8f0',
-                    borderRadius: '12px',
-                    marginBottom: '1.5rem',
-                    boxShadow: '0 4px 6px rgba(0, 0, 0, 0.07)',
-                }}
-            >
-                {imageError ? (
-                    <div
-                        style={{
-                            width: size,
-                            height: size,
-                            display: 'flex',
-                            alignItems: 'center',
-                            justifyContent: 'center',
-                            backgroundColor: '#fed7d7',
-                            color: '#c53030',
-                            border: '2px solid #feb2b2',
-                            borderRadius: '8px',
-                            fontSize: '0.875rem',
-                            fontWeight: '600'
-                        }}
-                    >
-                        ❌ QR Code failed to load
-                    </div>
-                ) : (
-                    <Image
-                        ref={imgRef}
-                        src={qrImageUrl}
-                        alt="QR Code"
-                        width={size}
-                        height={size}
-                        style={{
-                            display: 'block',
-                            borderRadius: '8px',
-                            border: '1px solid #e2e8f0'
-                        }}
-                        onError={handleImageError}
-                        onLoad={handleImageLoad}
-                        unoptimized={true}
+            <div className="saa" style={{ display: 'flex', justifyContent: 'center'}}>
+                <ImagePreview 
+                    imageUrl={imageUrl}
                     />
-                )}
+                <div
+                    style={{
+                        display: 'inline-block',
+                        padding: '1.5rem',
+                        backgroundColor: 'white',
+                        border: '2px solid #e2e8f0',
+                        borderRadius: '12px',
+                        marginBottom: '1.5rem',
+                        boxShadow: '0 4px 6px rgba(0, 0, 0, 0.07)',
+                    }}
+                >
+                    {imageError ? (
+                        <div
+                            style={{
+                                width: size,
+                                height: size,
+                                display: 'flex',
+                                alignItems: 'center',
+                                justifyContent: 'center',
+                                backgroundColor: '#fed7d7',
+                                color: '#c53030',
+                                border: '2px solid #feb2b2',
+                                borderRadius: '8px',
+                                fontSize: '0.875rem',
+                                fontWeight: '600'
+                            }}
+                        >
+                            ❌ QR Code failed to load
+                        </div>
+                    ) : (
+                        <Image
+                            ref={imgRef}
+                            src={qrImageUrl}
+                            alt="QR Code"
+                            width={size}
+                            height={size}
+                            style={{
+                                display: 'block',
+                                borderRadius: '8px',
+                                border: '1px solid #e2e8f0'
+                            }}
+                            onError={handleImageError}
+                            onLoad={handleImageLoad}
+                            unoptimized={true}
+                        />
+                    )}
+                </div>
             </div>
 
             <QRCodeButtons

--- a/admin/components/admin/FireworkListItem.tsx
+++ b/admin/components/admin/FireworkListItem.tsx
@@ -1,8 +1,10 @@
 import { dangerButtonStyle, fireworkItemStyle, statusBadgeStyle } from '@/styles/adminStyles';
 import type { Firework } from '@/hooks/useFireworks';
+import ImagePreview from "./ImagePreview"
 
 interface FireworkListItemProps {
   firework: Firework;
+  imageUrl: string | null;
   isSelected: boolean;
   isDeleting: boolean;
   onSelect: (firework: Firework) => void;
@@ -11,6 +13,7 @@ interface FireworkListItemProps {
 
 export default function FireworkListItem({
   firework,
+  imageUrl,
   isSelected,
   isDeleting,
   onSelect,
@@ -21,7 +24,7 @@ export default function FireworkListItem({
       style={fireworkItemStyle(isSelected)}
       onClick={() => onSelect(firework)}
     >
-      <div style={{ flex: 1 }}>
+      <div style={{ display: 'flex', gap: '0.5rem' }}>
         <div style={{ fontWeight: 'bold', marginBottom: '0.5rem', color: '#2d3748' }}>
           🎆 花火 #{firework.id}
         </div>
@@ -33,8 +36,12 @@ export default function FireworkListItem({
             📅 {firework.createdAt ? new Date(firework.createdAt).toLocaleDateString() : 'N/A'}
           </span>
         </div>
+        <ImagePreview 
+      imageUrl={imageUrl}
+      size={50}
+      />
       </div>
-
+      
       <div>
         <button
           onClick={(e) => {

--- a/admin/components/admin/FireworksListCard.tsx
+++ b/admin/components/admin/FireworksListCard.tsx
@@ -81,6 +81,7 @@ export default function FireworksListCard({
             <FireworkListItem
               key={firework.id}
               firework={firework}
+              imageUrl={firework.imageUrl}
               isSelected={selectedFirework?.id === firework.id}
               isDeleting={deletingIds.has(firework.id)}
               onSelect={onSelect}

--- a/admin/components/admin/ImagePreview.tsx
+++ b/admin/components/admin/ImagePreview.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import Image from "next/image";
+import { useState } from "react";
+
+interface ImagePreviewProps {
+  imageUrl?: string | null;
+  size?: number;
+}
+
+export default function ImagePreview({
+  imageUrl,
+  size = 250,
+}: ImagePreviewProps) {
+  const [hasError, setHasError] = useState(false);
+
+  if (!imageUrl || hasError) {
+    return (
+      <div
+        style={{
+          width: size,
+          height: size,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          backgroundColor: "#f7fafc",
+          border: "2px solid #e2e8f0",
+          borderRadius: "12px",
+          color: "#718096",
+          boxSizing: "content-box",
+        }}
+      >
+        {hasError ? "画像の読み込みに失敗しました" : "画像がありません"}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      style={{
+        width: size,
+        height: size,
+        backgroundColor: "white",
+        border: "2px solid #e2e8f0",
+        borderRadius: "12px",
+        boxShadow: "0 4px 6px rgba(0, 0, 0, 0.07)",
+        boxSizing: "content-box",
+      }}
+    >
+      <Image
+        src={imageUrl}
+        alt="花火画像のプレビュー"
+        width={size}
+        height={size}
+        unoptimized
+        onError={() => setHasError(true)}
+        style={{
+          width: "100%",
+          height: "100%",
+          objectFit: "contain",
+          display: "block",
+          borderRadius: "8px",
+        }}
+      />
+    </div>
+  );
+}

--- a/admin/components/admin/QRCodePanel.tsx
+++ b/admin/components/admin/QRCodePanel.tsx
@@ -33,6 +33,7 @@ export default function QRCodePanel({
           url={qrUrl}
           size={200}
           fireworkId={firework.id}
+          imageUrl={firework.imageUrl}
           originalImageFile={originalImageFile}
           onDownload={onDownload}
           onError={onError}

--- a/admin/hooks/useFireworks.ts
+++ b/admin/hooks/useFireworks.ts
@@ -3,6 +3,7 @@ import { useState, useEffect, useCallback } from 'react';
 export interface Firework {
   id: number;
   isShareable: boolean;
+  imageUrl: string | null;
   pixelData: boolean[];
   createdAt?: string;
   updatedAt?: string;


### PR DESCRIPTION
花火を選択した際の画像プレビューを表示するコンポーネントを追加した。

↓画像のように、選択した花火に応じて、preview画像が表示されるようにした。

<img width="1018" height="332" alt="image" src="https://github.com/user-attachments/assets/ed9e40e5-5249-41df-a32f-ee03b6b195db" />
<img width="1728" height="775" alt="image" src="https://github.com/user-attachments/assets/d7a0fb98-97ff-4b91-93a1-1e1109b713db" />
<img width="1761" height="763" alt="image" src="https://github.com/user-attachments/assets/9211f78e-38b5-4d6b-8964-130bb11bcf76" />
