### PR TITLE
[fix] add seaweedfs configuration for storage management

### DIFF
--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -49,6 +49,11 @@ services:
       SWAGGER_STG_URL: ${SWAGGER_STG_URL} # SwaggerUIのステージングURLを環境変数から取得
       ADMIN_URL: ${ADMIN_URL}             # 管理者画面のURLを環境変数から取得
       ADMIN_STG_URL: ${ADMIN_STG_URL}     # 管理者画面のステージングURLを環境変数から取得
+      STORAGE_ENDPOINT: http://seaweedfs:8333   # コンテナ間通信は内部サービス名を使用
+      STORAGE_PUBLIC_URL: ${STORAGE_PUBLIC_URL} # 画像の公開URL。.envで指定（例: https://hanabi-storage.nutfes.net）
+      STORAGE_BUCKET: fireworks
+      STORAGE_ACCESS_KEY: ${STORAGE_ACCESS_KEY}
+      STORAGE_SECRET_KEY: ${STORAGE_SECRET_KEY}
     ports:
       - "8080:8080"
     volumes:
@@ -57,6 +62,9 @@ services:
     command: "./start.sh"
     networks:
       - app_network
+    depends_on:
+      seaweedfs:
+        condition: service_healthy
   db:
     image: postgres
     container_name: postgres
@@ -71,6 +79,22 @@ services:
       - postgres-data:/var/lib/postgresql/data
     networks:
       - app_network
+  seaweedfs:
+    image: chrislusf/seaweedfs
+    command: "server -s3"
+    ports:
+      - "8333:8333"
+    volumes:
+      - seaweedfs-data:/data
+    networks:
+      - app_network
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:8333/"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 10s
   swagger-ui:
     image: swaggerapi/swagger-ui
     restart: unless-stopped
@@ -94,6 +118,7 @@ services:
 
 volumes:
   postgres-data:
+  seaweedfs-data:
 
 networks:
   app_network:


### PR DESCRIPTION
## 概要
本番用 `docker-compose.prod.yaml` に SeaweedFS(画像ストレージ)関連の設定が
一切存在せず、本番構成で起動すると API サーバーが画像ストレージへの接続に
失敗して panic する状態だった。開発用 `docker-compose.yaml` と同等の設定を
本番にも反映し、本番でも画像アップロード・保存・配信が機能するようにした。

## 背景
- APIコード(`api/main.go`, `api/infra/storage.go`)は SeaweedFS 接続を前提に実装済み
- 開発用 `docker-compose.yaml` には `seaweedfs` サービスと `STORAGE_*` 環境変数が揃っている
- 本番用 `docker-compose.prod.yaml` にはこれらが無く、`STORAGE_*` が空文字のまま
  `infra.NewStorageClient` が呼ばれて失敗 → `panic("failed to connect storage")` で
  API サーバー自体が起動できない状態だった