### PR TITLE
Feat/walt/user UI cleanup

### DIFF
--- a/user/src/components/common/ScanModal.tsx
+++ b/user/src/components/common/ScanModal.tsx
@@ -43,7 +43,21 @@ export default function ScanModal ({ isOpen, onScan, closeModal }: CommonModalPr
       <QrScanner 
         onScan={onScan} // QRコードスキャン時のコールバックを設定
       />
-			<button onClick={closeModal} className="modal-close" type="button">
+			<button
+				onClick={closeModal}
+				type="button"
+				style={{
+					marginTop: '12px',
+					padding: '8px 20px',
+					fontSize: '14px',
+					fontWeight: 600,
+					borderRadius: '10px',
+					border: 'none',
+					backgroundColor: '#f0b810',
+					color: '#1a1a1a',
+					cursor: 'pointer',
+				}}
+			>
 				閉じる
 			</button>
 		</Modal>

--- a/user/src/config/apiConfig.ts
+++ b/user/src/config/apiConfig.ts
@@ -1,2 +1,27 @@
 // 環境変数からAPIのベースURLを取得(orvalのmutatorで使用する. mutatorではviteの機能であるimport.meta.envを直接扱えないため、別ファイルで定義しておく)
-export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || "http://localhost:8080"; // デフォルトのベースURLを設定
+// VITE_API_BASE_URLが空の場合は現在のオリジン(window.location.origin)を使う。
+// これによりngrok等でフロントのみHTTPS公開した場合でも、Viteのdev server proxyを介して
+// 同一オリジンでAPIにアクセスできる(CORS・mixed contentを回避するため)。
+const envBaseUrl = import.meta.env.VITE_API_BASE_URL;
+export const API_BASE_URL =
+  envBaseUrl && envBaseUrl.length > 0
+    ? envBaseUrl
+    : typeof window !== "undefined"
+      ? window.location.origin
+      : "http://localhost:8080"; // デフォルトのベースURLを設定
+
+// APIが返す画像URL(SeaweedFSのSTORAGE_PUBLIC_URL基準の絶対URL、例: http://localhost:8333/...)を
+// 現在のオリジンからの相対パスに変換する。
+// ngrok等でフロントのみHTTPS公開した場合、絶対URLのlocalhostはスマホ自身を指してしまい読み込めないため、
+// 同一オリジン(Vite dev server proxy経由)でアクセスできるようにする。
+export function toSameOriginUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+    if (parsed.hostname === "localhost" || parsed.hostname === "127.0.0.1") {
+      return `${parsed.pathname}${parsed.search}`;
+    }
+    return url;
+  } catch {
+    return url;
+  }
+}

--- a/user/src/pages/Home.tsx
+++ b/user/src/pages/Home.tsx
@@ -9,11 +9,31 @@ import {
 import type { IllustrationFireworksType } from '../types/illustrationFireworksType';
 import type { ColorParticleData } from '../types/illustrationFireworksType';
 import { imageUrlToParticles } from '../utils/imageToParticles';
+import { toSameOriginUrl } from '../config/apiConfig';
 import { useGetFireworkById } from '../apiClient/fireworks/myARProjectAPI';
 import ScanModal from '../components/common/ScanModal';
 import type { HomeCanvasHandle } from '../canvas/HomeCanvas';
 
 import HomeCanvas from "../canvas/HomeCanvas";
+import {
+  overlayContainerStyle,
+  panelStyle,
+  primaryButtonStyle,
+  secondaryButtonStyle,
+  statusPillStyle,
+  errorPillStyle,
+  qualityRowContainerStyle,
+  qualityLabelStyle,
+  qualityRowStyle,
+  qualityButtonStyle,
+} from './homeStyles';
+
+// 画質レベル: 値が大きいほど画像を細かいグリッドに分解し、粒子数が増えて精細になる（その分重くなる）
+const QUALITY_LEVELS = [
+  { label: '低', resolution: 32 },
+  { label: '中', resolution: 64 },
+  { label: '高', resolution: 128 },
+] as const;
 
 // ===== Homeのページ =====
 // ページではデータフェッチやローカルストレージの読み書きを行う
@@ -24,10 +44,8 @@ export default function Home() {
   const [particleData, setParticleData] = useState<ColorParticleData | null>(null);
   const [isConverting, setIsConverting] = useState(false);
 
-  /* DEBUG START - 解像度調整UI（削除するときはここから DEBUG END まで消す） */
+  // 画質設定（画像を何×何のグリッドに分解するか）。既定は「中」
   const [resolution, setResolution] = useState(64);
-  const [pendingResolution, setPendingResolution] = useState(64);
-  /* DEBUG END */
 
   const [isOpen, setIsOpen] = useState(false);
   const [searchParams, setSearchParams] = useSearchParams();
@@ -86,8 +104,8 @@ export default function Home() {
 
     // 画像 → カラーパーティクル変換
     setIsConverting(true);
-    imageUrlToParticles(data.imageUrl, {
-      resolution, /* DEBUG - 固定値に戻す場合は resolution を 64 などに変更 */
+    imageUrlToParticles(toSameOriginUrl(data.imageUrl), {
+      resolution, // 画質設定（低32 / 中64 / 高128）
       whiteThreshold: 200,
       saturationThreshold: 30,
       includeWhite: false,
@@ -118,16 +136,6 @@ export default function Home() {
     homeCanvasRef.current?.resetCameraRotation();
   };
 
-  const buttonStyle: React.CSSProperties = {
-    width: '200px',
-    padding: '4px 8px',
-    fontSize: '16px',
-    cursor: 'pointer',
-    position: 'absolute',
-    left: '50%',
-    transform: 'translateX(-50%)',
-  };
-
   const isReady = !!particleData && !isConverting;
 
   return (
@@ -138,117 +146,57 @@ export default function Home() {
             ref={homeCanvasRef}
         />
 
-        <button
-            onClick={() => setIsOpen(true)}
-            style={{ ...buttonStyle, bottom: '20px' }}
-        >
-          QRコードをスキャン
-        </button>
+        <div style={overlayContainerStyle}>
+          <div style={panelStyle}>
+            {/* 画質セレクタ（低32 / 中64 / 高128） */}
+            <div style={qualityRowContainerStyle}>
+              <span style={qualityLabelStyle}>画質</span>
+              <div style={qualityRowStyle}>
+                {QUALITY_LEVELS.map((level) => (
+                    <button
+                        key={level.resolution}
+                        onClick={() => setResolution(level.resolution)}
+                        disabled={isConverting}
+                        style={qualityButtonStyle(resolution === level.resolution)}
+                    >
+                      {level.label}
+                    </button>
+                ))}
+              </div>
+            </div>
 
-        {isLoading || isConverting ? (
-            <div style={{
-              ...buttonStyle,
-              bottom: '80px',
-              backgroundColor: 'rgba(255,255,255,0.6)',
-              textAlign: 'center',
-            }}>
-              {isLoading ? '読み込み中...' : '画像を変換中...'}
-            </div>
-        ) : isReady ? (
-            <>
-              <button
-                  onClick={handleLaunch}
-                  style={{
-                    ...buttonStyle,
-                    backgroundColor: '#f0b810ff',
-                    bottom: '120px',
-                  }}
-              >
-                花火を打ち上げる
-              </button>
-              <button
-                  onClick={resetCameraRotation}
-                  style={{ ...buttonStyle, bottom: '60px' }}
-              >
-                カメラのリセット
-              </button>
-            </>
-        ) : (
-            <div style={{
-              backgroundColor: 'rgba(255, 255, 255, 0.6)',
-              width: 'auto',
-              padding: '4px 8px',
-              fontSize: '16px',
-              position: 'absolute',
-              bottom: '80px',
-              left: '50%',
-              transform: 'translateX(-50%)',
-            }}>
-              花火が読み込めませんでした<br />
-              別のQRコードをスキャンしてください
-            </div>
-        )}
+            {isLoading || isConverting ? (
+                <div style={statusPillStyle}>
+                  {isLoading ? '読み込み中...' : '画像を変換中...'}
+                </div>
+            ) : isReady ? (
+                <>
+                  <button onClick={handleLaunch} style={primaryButtonStyle}>
+                    🎆 花火を打ち上げる
+                  </button>
+                  <button onClick={resetCameraRotation} style={secondaryButtonStyle}>
+                    カメラのリセット
+                  </button>
+                </>
+            ) : (
+                <div style={errorPillStyle}>
+                  花火が読み込めませんでした<br />
+                  別のQRコードをスキャンしてください
+                </div>
+            )}
+
+            {/* QRコードのスキャンはどの状態でも常に行えるようにする */}
+            <button onClick={() => setIsOpen(true)} style={secondaryButtonStyle}>
+              QRコードをスキャン
+            </button>
+          </div>
+        </div>
 
         <ScanModal
             isOpen={isOpen}
             onScan={onScan}
             closeModal={() => setIsOpen(false)}
         />
-
-        {/* DEBUG START - 解像度調整パネル（削除するときはここから DEBUG END まで消す） */}
-        <div style={{
-          position: 'absolute',
-          top: '12px',
-          left: '12px',
-          backgroundColor: 'rgba(0,0,0,0.65)',
-          color: 'white',
-          padding: '10px 14px',
-          borderRadius: '8px',
-          fontSize: '13px',
-          display: 'flex',
-          flexDirection: 'column',
-          gap: '6px',
-          zIndex: 1000,
-        }}>
-          <div style={{ fontWeight: 'bold' }}>🔧 解像度調整（DEBUG）</div>
-          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-            <span>16</span>
-            <input
-                type="range"
-                min={16}
-                max={512}
-                step={16}
-                value={pendingResolution}
-                onChange={(e) => setPendingResolution(Number(e.target.value))}
-                style={{ width: '120px' }}
-            />
-            <span>512</span>
-          </div>
-          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '8px' }}>
-            <span>選択中: <strong>{pendingResolution}×{pendingResolution}</strong></span>
-            <button
-                onClick={() => setResolution(pendingResolution)}
-                disabled={isConverting}
-                style={{
-                  padding: '2px 10px',
-                  fontSize: '12px',
-                  cursor: isConverting ? 'not-allowed' : 'pointer',
-                  borderRadius: '4px',
-                  border: 'none',
-                  backgroundColor: '#f0b810',
-                  fontWeight: 'bold',
-                }}
-            >
-              {isConverting ? '変換中...' : '適用'}
-            </button>
-          </div>
-          {particleData && (
-              <div style={{ fontSize: '11px', opacity: 0.8 }}>
-                現在: {resolution}×{resolution} / {particleData.particles.length} 粒子
-              </div>
-          )}
-        </div>
-        {/* DEBUG END */}
       </div>
   );
 }

--- a/user/src/pages/homeStyles.ts
+++ b/user/src/pages/homeStyles.ts
@@ -1,0 +1,109 @@
+import type { CSSProperties } from 'react';
+
+// ===== Home ページの見た目に関する定数・スタイル定義 =====
+// admin/styles/adminStyles.ts と同様に、インラインstyleオブジェクトをここへ集約する。
+
+export const ACCENT_COLOR = '#f0b810';
+
+/** 画面下部中央に浮かぶコントロールパネル全体の位置 */
+export const overlayContainerStyle: CSSProperties = {
+  position: 'absolute',
+  bottom: '24px',
+  left: '50%',
+  transform: 'translateX(-50%)',
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  gap: '10px',
+  width: 'min(340px, 92vw)',
+};
+
+/** コントロールパネルの背景カード */
+export const panelStyle: CSSProperties = {
+  width: '100%',
+  boxSizing: 'border-box',
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'stretch',
+  gap: '10px',
+  padding: '14px 16px',
+  borderRadius: '16px',
+  backgroundColor: 'rgba(20, 20, 24, 0.6)',
+  backdropFilter: 'blur(6px)',
+  boxShadow: '0 4px 16px rgba(0, 0, 0, 0.25)',
+};
+
+const baseButtonStyle: CSSProperties = {
+  boxSizing: 'border-box',
+  width: '100%',
+  padding: '12px 16px',
+  fontSize: '15px',
+  fontWeight: 600,
+  borderRadius: '12px',
+  border: 'none',
+  cursor: 'pointer',
+};
+
+/** 主要アクション（花火を打ち上げる） */
+export const primaryButtonStyle: CSSProperties = {
+  ...baseButtonStyle,
+  backgroundColor: ACCENT_COLOR,
+  color: '#1a1a1a',
+};
+
+/** 副次アクション（カメラのリセット・QRスキャン） */
+export const secondaryButtonStyle: CSSProperties = {
+  ...baseButtonStyle,
+  backgroundColor: 'rgba(255, 255, 255, 0.15)',
+  color: '#fff',
+  border: '1px solid rgba(255, 255, 255, 0.25)',
+};
+
+/** 読み込み中・変換中の状態表示 */
+export const statusPillStyle: CSSProperties = {
+  padding: '10px 16px',
+  borderRadius: '12px',
+  backgroundColor: 'rgba(20, 20, 24, 0.6)',
+  color: '#fff',
+  fontSize: '14px',
+  textAlign: 'center',
+};
+
+/** エラー表示（花火が読み込めなかった場合） */
+export const errorPillStyle: CSSProperties = {
+  ...statusPillStyle,
+  backgroundColor: 'rgba(120, 20, 20, 0.6)',
+  lineHeight: 1.6,
+};
+
+/** 画質セレクタの行 */
+export const qualityRowContainerStyle: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '6px',
+};
+
+export const qualityLabelStyle: CSSProperties = {
+  fontSize: '12px',
+  color: 'rgba(255, 255, 255, 0.75)',
+};
+
+export const qualityRowStyle: CSSProperties = {
+  display: 'flex',
+  gap: '6px',
+};
+
+/** 画質セレクタの各ボタン（選択状態でアクセントカラーに切り替え） */
+export function qualityButtonStyle(isActive: boolean): CSSProperties {
+  return {
+    flex: 1,
+    padding: '8px 0',
+    fontSize: '13px',
+    fontWeight: 600,
+    borderRadius: '8px',
+    border: isActive ? `1px solid ${ACCENT_COLOR}` : '1px solid rgba(255, 255, 255, 0.25)',
+    backgroundColor: isActive ? ACCENT_COLOR : 'rgba(255, 255, 255, 0.08)',
+    color: isActive ? '#1a1a1a' : '#fff',
+    cursor: 'pointer',
+  };
+}

--- a/user/vite.config.ts
+++ b/user/vite.config.ts
@@ -32,10 +32,24 @@ export default defineConfig({
     },
     allowedHosts: [
       '.local',
-      'localhost', 
-      // '16dbd1de098c.ngrok-free.app',
+      'localhost',
+      '.ngrok-free.app', // スマホ実機検証用（ngrok無料枠のランダムサブドメインを許可）
+      '.ngrok-free.dev', // スマホ実機検証用（ngrok無料枠の新ドメインサフィックス）
       'hanabi.nutfes.net',
       'hanabi-stg.nutfes.net',
-    ]
+    ],
+    proxy: {
+      // スマホ実機検証用: ngrokでフロントのみ公開した際、同一オリジンでSeaweedFS(画像)へ中継する
+      // ('/fireworks'より先に定義し、'/fireworks/images'を優先的にマッチさせる)
+      '/fireworks/images': {
+        target: 'http://seaweedfs:8333',
+        changeOrigin: true,
+      },
+      // スマホ実機検証用: ngrokでフロントのみ公開した際、同一オリジンでAPIへ中継する
+      '/fireworks': {
+        target: 'http://app:8080',
+        changeOrigin: true,
+      },
+    },
   }
 })


### PR DESCRIPTION
## 概要
ユーザー向けHomeページのUIを整理し、DEBUG用だった解像度スライダーを
一般ユーザー向けの3段階画質セレクタに置き換えた。

## 背景
- ボタン類が `position:absolute` の個別オフセット(bottom 20/60/120px)で
  バラバラに配置されており、見た目が雑然としていた
- 解像度設定が「🔧 解像度調整（DEBUG）」パネルとして16〜512の任意値スライダー
  ＋適用ボタンのまま一般ユーザーに露出していた

## 変更内容
- `user/src/pages/homeStyles.ts`（新規）
  - admin/styles/adminStyles.ts に倣い、Home用のスタイル定数を集約
- `user/src/pages/Home.tsx`
  - DEBUG解像度スライダーを削除し、「画質: 低32 / 中64 / 高128」の3ボタン
    セレクタに置換（既定=中64、選択即反映）
  - 個別配置だったボタンを、画面下部中央の統一パネルに集約
- `user/src/components/common/ScanModal.tsx`
  - 閉じるボタンの未定義クラス `modal-close` を実スタイルに置換
  
  ## 確認事項
- [x] 実際のスマホ幅での見た目確認
- [x] 画質「低/中/高」を切り替えて花火の精細さが変わることの確認