### PR TITLE
Feat/ponyo/image crop modal

### DIFF
--- a/admin/app/page.tsx
+++ b/admin/app/page.tsx
@@ -39,7 +39,7 @@ export default function Home() {
             onDateChange={f.setSelectedDate}
             onSelect={f.selectFirework}
             onDelete={f.deleteFirework}
-            onFileChange={f.handleFileChange}
+            onEditedFile={f.setSelectedFile}
             onShareableChange={f.setIsShareable}
             onCreate={f.createFirework}
           />

--- a/admin/components/admin/AddFireworkForm.tsx
+++ b/admin/components/admin/AddFireworkForm.tsx
@@ -39,6 +39,10 @@ export default function AddFireworkForm({
       setEditorMeta({ fileName: file.name, mimeType: file.type });
       setIsEditorOpen(true);
     };
+    reader.onerror = () => {
+      console.error('Failed to read image file:', reader.error);
+      window.alert('⚠️ 画像ファイルの読み込みに失敗しました。別のファイルでお試しください。');
+    };
     reader.readAsDataURL(file);
   };
 

--- a/admin/components/admin/AddFireworkForm.tsx
+++ b/admin/components/admin/AddFireworkForm.tsx
@@ -1,13 +1,22 @@
-import { primaryButtonStyle, inputStyle } from '@/styles/adminStyles';
+'use client';
+
+import { useState } from 'react';
+import { primaryButtonStyle, secondaryButtonStyle, inputStyle } from '@/styles/adminStyles';
+import ImageCropModal from './ImageCropModal';
 
 interface AddFireworkFormProps {
   nextId: number;
   selectedFile: File | null;
   isShareable: boolean;
   isCreating: boolean;
-  onFileChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onEditedFile: (file: File) => void;
   onShareableChange: (checked: boolean) => void;
   onCreate: () => void;
+}
+
+interface EditorMeta {
+  fileName: string;
+  mimeType: string;
 }
 
 export default function AddFireworkForm({
@@ -15,10 +24,46 @@ export default function AddFireworkForm({
   selectedFile,
   isShareable,
   isCreating,
-  onFileChange,
+  onEditedFile,
   onShareableChange,
   onCreate,
 }: AddFireworkFormProps) {
+  const [rawImageSrc, setRawImageSrc] = useState<string | null>(null);
+  const [editorMeta, setEditorMeta] = useState<EditorMeta | null>(null);
+  const [isEditorOpen, setIsEditorOpen] = useState(false);
+
+  const openEditorForFile = (file: File) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      setRawImageSrc(reader.result as string);
+      setEditorMeta({ fileName: file.name, mimeType: file.type });
+      setIsEditorOpen(true);
+    };
+    reader.readAsDataURL(file);
+  };
+
+  const handleFileInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files && e.target.files.length > 0) {
+      openEditorForFile(e.target.files[0]);
+    }
+    e.target.value = '';
+  };
+
+  const handleEditAgain = () => {
+    if (selectedFile) {
+      openEditorForFile(selectedFile);
+    }
+  };
+
+  const handleEditorConfirm = (file: File) => {
+    onEditedFile(file);
+    setIsEditorOpen(false);
+  };
+
+  const handleEditorCancel = () => {
+    setIsEditorOpen(false);
+  };
+
   return (
     <div style={{
       marginTop: '2rem',
@@ -53,21 +98,30 @@ export default function AddFireworkForm({
         <input
           type="file"
           accept="image/*"
-          onChange={onFileChange}
+          onChange={handleFileInputChange}
           style={{
             ...inputStyle,
             borderColor: selectedFile ? '#48bb78' : '#e2e8f0',
           }}
         />
         {selectedFile && (
-          <p style={{
-            fontSize: '0.875rem',
-            color: '#48bb78',
-            marginBottom: '1rem',
-            fontWeight: '500',
-          }}>
-            ✅ 選択中: {selectedFile.name}
-          </p>
+          <div style={{ marginBottom: '1rem' }}>
+            <p style={{
+              fontSize: '0.875rem',
+              color: '#48bb78',
+              marginBottom: '0.5rem',
+              fontWeight: '500',
+            }}>
+              ✅ 選択中: {selectedFile.name}
+            </p>
+            <button
+              type="button"
+              onClick={handleEditAgain}
+              style={{ ...secondaryButtonStyle, width: '100%' }}
+            >
+              ✂️ 画像を編集
+            </button>
+          </div>
         )}
 
         <label style={{
@@ -111,6 +165,16 @@ export default function AddFireworkForm({
           {isCreating ? '⏳ 作成中...' : `🚀 花火を作成 #${nextId}`}
         </button>
       </div>
+
+      {isEditorOpen && rawImageSrc && editorMeta && (
+        <ImageCropModal
+          imageSrc={rawImageSrc}
+          fileName={editorMeta.fileName}
+          mimeType={editorMeta.mimeType}
+          onConfirm={handleEditorConfirm}
+          onCancel={handleEditorCancel}
+        />
+      )}
     </div>
   );
 }

--- a/admin/components/admin/FireworksListCard.tsx
+++ b/admin/components/admin/FireworksListCard.tsx
@@ -18,7 +18,7 @@ interface FireworksListCardProps {
   onDateChange: (date: string) => void;
   onSelect: (firework: Firework) => void;
   onDelete: (id: number) => void;
-  onFileChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onEditedFile: (file: File) => void;
   onShareableChange: (checked: boolean) => void;
   onCreate: () => void;
 }
@@ -37,7 +37,7 @@ export default function FireworksListCard({
   onDateChange,
   onSelect,
   onDelete,
-  onFileChange,
+  onEditedFile,
   onShareableChange,
   onCreate,
 }: FireworksListCardProps) {
@@ -95,7 +95,7 @@ export default function FireworksListCard({
         selectedFile={selectedFile}
         isShareable={isShareable}
         isCreating={isCreating}
-        onFileChange={onFileChange}
+        onEditedFile={onEditedFile}
         onShareableChange={onShareableChange}
         onCreate={onCreate}
       />

--- a/admin/components/admin/ImageCropModal.tsx
+++ b/admin/components/admin/ImageCropModal.tsx
@@ -73,6 +73,9 @@ export default function ImageCropModal({
       }}
     >
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="画像を編集"
         style={{
           backgroundColor: 'white',
           borderRadius: '12px',

--- a/admin/components/admin/ImageCropModal.tsx
+++ b/admin/components/admin/ImageCropModal.tsx
@@ -30,6 +30,7 @@ export default function ImageCropModal({
   const [rotation, setRotation] = useState(0);
   const [croppedAreaPixels, setCroppedAreaPixels] = useState<Area | null>(null);
   const [isProcessing, setIsProcessing] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   const handleCropComplete = useCallback((_croppedArea: Area, areaPixels: Area) => {
     setCroppedAreaPixels(areaPixels);
@@ -46,11 +47,13 @@ export default function ImageCropModal({
   const handleConfirm = useCallback(async () => {
     if (!croppedAreaPixels) return;
     setIsProcessing(true);
+    setErrorMessage(null);
     try {
       const file = await getCroppedImg(imageSrc, croppedAreaPixels, rotation, fileName, mimeType);
       onConfirm(file);
     } catch (error) {
       console.error('Failed to crop image:', error);
+      setErrorMessage('⚠️ 画像の処理に失敗しました。もう一度お試しください。');
     } finally {
       setIsProcessing(false);
     }
@@ -99,6 +102,8 @@ export default function ImageCropModal({
             zoom={zoom}
             rotation={rotation}
             aspect={1}
+            minZoom={0.1}
+            maxZoom={3}
             onCropChange={setCrop}
             onZoomChange={setZoom}
             onRotationChange={setRotation}
@@ -107,12 +112,13 @@ export default function ImageCropModal({
         </div>
 
         <div style={{ marginTop: '1rem' }}>
-          <label style={{ display: 'block', fontSize: '0.875rem', color: '#4a5568', marginBottom: '0.25rem' }}>
+          <label htmlFor="crop-zoom" style={{ display: 'block', fontSize: '0.875rem', color: '#4a5568', marginBottom: '0.25rem' }}>
             🔍 ズーム
           </label>
           <input
+            id="crop-zoom"
             type="range"
-            min={1}
+            min={0.1}
             max={3}
             step={0.01}
             value={zoom}
@@ -122,10 +128,11 @@ export default function ImageCropModal({
         </div>
 
         <div style={{ marginTop: '1rem' }}>
-          <label style={{ display: 'block', fontSize: '0.875rem', color: '#4a5568', marginBottom: '0.25rem' }}>
+          <label htmlFor="crop-rotation" style={{ display: 'block', fontSize: '0.875rem', color: '#4a5568', marginBottom: '0.25rem' }}>
             🔄 回転
           </label>
           <input
+            id="crop-rotation"
             type="range"
             min={0}
             max={360}
@@ -151,6 +158,12 @@ export default function ImageCropModal({
             </button>
           </div>
         </div>
+
+        {errorMessage && (
+          <p style={{ color: '#e53e3e', fontSize: '0.875rem', marginTop: '1rem', fontWeight: '500' }}>
+            {errorMessage}
+          </p>
+        )}
 
         <div style={{ display: 'flex', gap: '0.5rem', marginTop: '1.5rem' }}>
           <button

--- a/admin/components/admin/ImageCropModal.tsx
+++ b/admin/components/admin/ImageCropModal.tsx
@@ -1,0 +1,186 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import Cropper from 'react-easy-crop';
+import type { Area, Point } from 'react-easy-crop';
+import { primaryButtonStyle, secondaryButtonStyle } from '@/styles/adminStyles';
+import { getCroppedImg } from '@/utils/cropImage';
+
+interface ImageCropModalProps {
+  imageSrc: string;
+  fileName: string;
+  mimeType: string;
+  onConfirm: (file: File) => void;
+  onCancel: () => void;
+}
+
+function normalizeRotation(rotation: number): number {
+  return ((rotation % 360) + 360) % 360;
+}
+
+export default function ImageCropModal({
+  imageSrc,
+  fileName,
+  mimeType,
+  onConfirm,
+  onCancel,
+}: ImageCropModalProps) {
+  const [crop, setCrop] = useState<Point>({ x: 0, y: 0 });
+  const [zoom, setZoom] = useState(1);
+  const [rotation, setRotation] = useState(0);
+  const [croppedAreaPixels, setCroppedAreaPixels] = useState<Area | null>(null);
+  const [isProcessing, setIsProcessing] = useState(false);
+
+  const handleCropComplete = useCallback((_croppedArea: Area, areaPixels: Area) => {
+    setCroppedAreaPixels(areaPixels);
+  }, []);
+
+  const handleRotateLeft = useCallback(() => {
+    setRotation((prev) => normalizeRotation(prev - 90));
+  }, []);
+
+  const handleRotateRight = useCallback(() => {
+    setRotation((prev) => normalizeRotation(prev + 90));
+  }, []);
+
+  const handleConfirm = useCallback(async () => {
+    if (!croppedAreaPixels) return;
+    setIsProcessing(true);
+    try {
+      const file = await getCroppedImg(imageSrc, croppedAreaPixels, rotation, fileName, mimeType);
+      onConfirm(file);
+    } catch (error) {
+      console.error('Failed to crop image:', error);
+    } finally {
+      setIsProcessing(false);
+    }
+  }, [imageSrc, croppedAreaPixels, rotation, fileName, mimeType, onConfirm]);
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        inset: 0,
+        backgroundColor: 'rgba(0, 0, 0, 0.6)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 1000,
+        padding: '1rem',
+      }}
+    >
+      <div
+        style={{
+          backgroundColor: 'white',
+          borderRadius: '12px',
+          padding: '1.5rem',
+          width: '100%',
+          maxWidth: '480px',
+          boxShadow: '0 10px 25px rgba(0, 0, 0, 0.2)',
+        }}
+      >
+        <h3 style={{ fontWeight: 'bold', marginBottom: '1rem', color: '#2d3748' }}>
+          ✂️ 画像を編集
+        </h3>
+
+        <div
+          style={{
+            position: 'relative',
+            width: '100%',
+            height: '320px',
+            backgroundColor: '#1a202c',
+            borderRadius: '8px',
+            overflow: 'hidden',
+          }}
+        >
+          <Cropper
+            image={imageSrc}
+            crop={crop}
+            zoom={zoom}
+            rotation={rotation}
+            aspect={1}
+            onCropChange={setCrop}
+            onZoomChange={setZoom}
+            onRotationChange={setRotation}
+            onCropComplete={handleCropComplete}
+          />
+        </div>
+
+        <div style={{ marginTop: '1rem' }}>
+          <label style={{ display: 'block', fontSize: '0.875rem', color: '#4a5568', marginBottom: '0.25rem' }}>
+            🔍 ズーム
+          </label>
+          <input
+            type="range"
+            min={1}
+            max={3}
+            step={0.01}
+            value={zoom}
+            onChange={(e) => setZoom(Number(e.target.value))}
+            style={{ width: '100%' }}
+          />
+        </div>
+
+        <div style={{ marginTop: '1rem' }}>
+          <label style={{ display: 'block', fontSize: '0.875rem', color: '#4a5568', marginBottom: '0.25rem' }}>
+            🔄 回転
+          </label>
+          <input
+            type="range"
+            min={0}
+            max={360}
+            step={1}
+            value={rotation}
+            onChange={(e) => setRotation(Number(e.target.value))}
+            style={{ width: '100%' }}
+          />
+          <div style={{ display: 'flex', gap: '0.5rem', marginTop: '0.5rem' }}>
+            <button
+              type="button"
+              onClick={handleRotateLeft}
+              style={{ ...secondaryButtonStyle, flex: 1 }}
+            >
+              ⟲ 左90°
+            </button>
+            <button
+              type="button"
+              onClick={handleRotateRight}
+              style={{ ...secondaryButtonStyle, flex: 1 }}
+            >
+              ⟳ 右90°
+            </button>
+          </div>
+        </div>
+
+        <div style={{ display: 'flex', gap: '0.5rem', marginTop: '1.5rem' }}>
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={isProcessing}
+            style={{
+              ...secondaryButtonStyle,
+              flex: 1,
+              opacity: isProcessing ? 0.6 : 1,
+              cursor: isProcessing ? 'not-allowed' : 'pointer',
+            }}
+          >
+            ✖️ キャンセル
+          </button>
+          <button
+            type="button"
+            onClick={handleConfirm}
+            disabled={isProcessing || !croppedAreaPixels}
+            style={{
+              ...primaryButtonStyle,
+              flex: 1,
+              opacity: isProcessing || !croppedAreaPixels ? 0.6 : 1,
+              cursor: isProcessing || !croppedAreaPixels ? 'not-allowed' : 'pointer',
+            }}
+          >
+            {isProcessing ? '⏳ 処理中...' : '✅ 確定'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/admin/hooks/useFireworks.ts
+++ b/admin/hooks/useFireworks.ts
@@ -276,12 +276,6 @@ export function useFireworks() {
     }
   }, [selectedFile, isShareable, API_URL, fetchFireworks, fetchLatestId, saveImageToLocalStorage]);
 
-  const handleFileChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    if (e.target.files && e.target.files.length > 0) {
-      setSelectedFile(e.target.files[0]);
-    }
-  }, []);
-
   const deleteFirework = useCallback(async (fireworkId: number) => {
     if (!confirm(`Are you sure you want to delete firework #${fireworkId}? This action cannot be undone.`)) {
       return;
@@ -365,9 +359,9 @@ export function useFireworks() {
     setError,
     setSelectedDate,
     setIsShareable,
+    setSelectedFile,
     // handlers
     selectFirework,
-    handleFileChange,
     createFirework,
     deleteFirework,
     fetchFireworks,

--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -13,7 +13,8 @@
         "qrcode-generator": "^2.0.4",
         "qrcode.react": "^4.2.0",
         "react": "19.0.0",
-        "react-dom": "19.0.0"
+        "react-dom": "19.0.0",
+        "react-easy-crop": "^6.2.2"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -3557,6 +3558,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/normalize-wheel": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/normalize-wheel/-/normalize-wheel-1.0.1.tgz",
+      "integrity": "sha512-1OnlAPZ3zgrk8B91HyRj+eVv+kS5u+Z0SCsak6Xil/kmgEia50ga7zfkumayonZrImffAxPU/5WcyGhzetHNPA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "dev": true,
@@ -4039,6 +4046,19 @@
       },
       "peerDependencies": {
         "react": "^19.0.0"
+      }
+    },
+    "node_modules/react-easy-crop": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/react-easy-crop/-/react-easy-crop-6.2.2.tgz",
+      "integrity": "sha512-b0HOicSvLYoNk1yvZTwjH8sNjF5uD9xLtWrSDnv+fx1dXTbwd8bNLQaP6gjXw//A+tni9Mw5KDmPNOEjKF55NQ==",
+      "license": "MIT",
+      "dependencies": {
+        "normalize-wheel": "^1.0.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.4.0",
+        "react-dom": ">=16.4.0"
       }
     },
     "node_modules/react-is": {

--- a/admin/package.json
+++ b/admin/package.json
@@ -14,7 +14,8 @@
     "qrcode-generator": "^2.0.4",
     "qrcode.react": "^4.2.0",
     "react": "19.0.0",
-    "react-dom": "19.0.0"
+    "react-dom": "19.0.0",
+    "react-easy-crop": "^6.2.2"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/admin/utils/cropImage.ts
+++ b/admin/utils/cropImage.ts
@@ -1,0 +1,80 @@
+import type { Area } from 'react-easy-crop';
+
+function createImage(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const image = new Image();
+    image.addEventListener('load', () => resolve(image));
+    image.addEventListener('error', (error) => reject(error));
+    image.src = src;
+  });
+}
+
+function toRadians(degrees: number): number {
+  return (degrees * Math.PI) / 180;
+}
+
+/**
+ * Crops and rotates an image, returning the result as a File.
+ * Follows the canvas approach documented by react-easy-crop:
+ * draw the source image rotated onto a bounding-box canvas, then
+ * extract the cropped area onto a second canvas of the final size.
+ */
+export async function getCroppedImg(
+  imageSrc: string,
+  croppedAreaPixels: Area,
+  rotation: number,
+  fileName: string,
+  mimeType: string
+): Promise<File> {
+  const image = await createImage(imageSrc);
+
+  const rotRad = toRadians(rotation);
+  const sin = Math.abs(Math.sin(rotRad));
+  const cos = Math.abs(Math.cos(rotRad));
+  const boundingWidth = image.width * cos + image.height * sin;
+  const boundingHeight = image.width * sin + image.height * cos;
+
+  const rotateCanvas = document.createElement('canvas');
+  rotateCanvas.width = boundingWidth;
+  rotateCanvas.height = boundingHeight;
+  const rotateCtx = rotateCanvas.getContext('2d');
+  if (!rotateCtx) {
+    throw new Error('Failed to get 2D canvas context');
+  }
+
+  rotateCtx.translate(boundingWidth / 2, boundingHeight / 2);
+  rotateCtx.rotate(rotRad);
+  rotateCtx.drawImage(image, -image.width / 2, -image.height / 2);
+
+  const outputCanvas = document.createElement('canvas');
+  outputCanvas.width = croppedAreaPixels.width;
+  outputCanvas.height = croppedAreaPixels.height;
+  const outputCtx = outputCanvas.getContext('2d');
+  if (!outputCtx) {
+    throw new Error('Failed to get 2D canvas context');
+  }
+
+  outputCtx.drawImage(
+    rotateCanvas,
+    croppedAreaPixels.x,
+    croppedAreaPixels.y,
+    croppedAreaPixels.width,
+    croppedAreaPixels.height,
+    0,
+    0,
+    croppedAreaPixels.width,
+    croppedAreaPixels.height
+  );
+
+  const outputType = mimeType || 'image/png';
+
+  return new Promise((resolve, reject) => {
+    outputCanvas.toBlob((blob) => {
+      if (!blob) {
+        reject(new Error('Failed to generate cropped image blob'));
+        return;
+      }
+      resolve(new File([blob], fileName, { type: outputType }));
+    }, outputType);
+  });
+}

--- a/admin/utils/cropImage.ts
+++ b/admin/utils/cropImage.ts
@@ -73,7 +73,8 @@ export async function getCroppedImg(
     croppedAreaPixels.height
   );
 
-  const outputType = mimeType || 'image/png';
+  const supportedTypes = new Set(['image/png', 'image/jpeg', 'image/webp']);
+  const outputType = supportedTypes.has(mimeType) ? mimeType : 'image/png';
 
   return new Promise((resolve, reject) => {
     outputCanvas.toBlob((blob) => {

--- a/admin/utils/cropImage.ts
+++ b/admin/utils/cropImage.ts
@@ -4,7 +4,7 @@ function createImage(src: string): Promise<HTMLImageElement> {
   return new Promise((resolve, reject) => {
     const image = new Image();
     image.addEventListener('load', () => resolve(image));
-    image.addEventListener('error', (error) => reject(error));
+    image.addEventListener('error', () => reject(new Error('Failed to load image')));
     image.src = src;
   });
 }
@@ -28,11 +28,14 @@ export async function getCroppedImg(
 ): Promise<File> {
   const image = await createImage(imageSrc);
 
+  const naturalWidth = image.naturalWidth;
+  const naturalHeight = image.naturalHeight;
+
   const rotRad = toRadians(rotation);
   const sin = Math.abs(Math.sin(rotRad));
   const cos = Math.abs(Math.cos(rotRad));
-  const boundingWidth = image.width * cos + image.height * sin;
-  const boundingHeight = image.width * sin + image.height * cos;
+  const boundingWidth = Math.ceil(naturalWidth * cos + naturalHeight * sin);
+  const boundingHeight = Math.ceil(naturalWidth * sin + naturalHeight * cos);
 
   const rotateCanvas = document.createElement('canvas');
   rotateCanvas.width = boundingWidth;
@@ -42,9 +45,11 @@ export async function getCroppedImg(
     throw new Error('Failed to get 2D canvas context');
   }
 
+  rotateCtx.fillStyle = '#ffffff';
+  rotateCtx.fillRect(0, 0, boundingWidth, boundingHeight);
   rotateCtx.translate(boundingWidth / 2, boundingHeight / 2);
   rotateCtx.rotate(rotRad);
-  rotateCtx.drawImage(image, -image.width / 2, -image.height / 2);
+  rotateCtx.drawImage(image, -naturalWidth / 2, -naturalHeight / 2);
 
   const outputCanvas = document.createElement('canvas');
   outputCanvas.width = croppedAreaPixels.width;
@@ -54,6 +59,8 @@ export async function getCroppedImg(
     throw new Error('Failed to get 2D canvas context');
   }
 
+  outputCtx.fillStyle = '#ffffff';
+  outputCtx.fillRect(0, 0, croppedAreaPixels.width, croppedAreaPixels.height);
   outputCtx.drawImage(
     rotateCanvas,
     croppedAreaPixels.x,


### PR DESCRIPTION
## 概要
トリミング・回転機能の追加

## 背景・目的
-正方形以外の画像をアップロードすると表示時に歪んでしまう問題があるためアップロード前に1:1でトリミングできるようにした。
-回転機能の追加
<table>
  <tr>
    <td>
       <img width="356" height="491" alt="スクリーンショット 2026-07-19 173945" src="https://github.com/user-attachments/assets/33d52d3c-c074-4b9f-bc08-cbc3892f49af" />
    </td>
    <td>
      <img width="351" height="494" alt="スクリーンショット 2026-07-19 174017" src="https://github.com/user-attachments/assets/e758ccd7-a022-43a4-ac73-3e386f0afd7f" />
    </td>
  </tr>
</table>

## 変更内容
- `react-easy-crop` を導入し、トリミング・ズーム・回転に対応した
  `ImageCropModal` コンポーネントを新規作成
- クロップ結果を canvas で焼き込み `File`化するユーティリティ
  (`utils/cropImage.ts`) を追加
- 画像ファイル選択後に自動で編集モーダルを開き、確定後の画像のみを
  アップロード対象にするようフローを変更
  - 選択済み画像に対しても「✂️ 画像を編集」ボタンから再編集可能
- ズームを1倍未満にも対応し、縦長・横長の画像でも全体を正方形の枠内に
  収められるように変更（枠からはみ出た余白は白で塗りつぶし、花火化処理で
  背景として自然に除外されるようにしています）

## 動作確認
- ローカルで以下を手動確認
  - 画像選択 → 編集モーダルが自動で開く
  - ドラッグでのトリミング位置調整 / ズーム（拡大・縮小）/ 回転スライダー・90°ボタンが機能する
  - 「確定」で編集後画像が反映され、「花火を作成」でアップロードされる
  - 「画像を編集」ボタンで再編集、「キャンセル」で元の選択を維持できる