### PR TITLE
本番環境のデプロイ設定とCloudflare Tunnel構成を修正

### DIFF
--- a/admin/next.config.ts
+++ b/admin/next.config.ts
@@ -1,7 +1,14 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  async rewrites() {
+    return [
+      {
+        source: "/api/:path*",
+        destination: "http://app:8080/:path*",
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -31,6 +31,8 @@ services:
       - /app/.next
     environment:
       NEXT_PUBLIC_API_URL: ${API_BASE_URL}
+      ADMIN_USERNAME: ${ADMIN_USERNAME}
+      ADMIN_PASSWORD: ${ADMIN_PASSWORD}
     networks:
       - app_network
     depends_on:
@@ -54,8 +56,6 @@ services:
       STORAGE_BUCKET: fireworks
       STORAGE_ACCESS_KEY: ${STORAGE_ACCESS_KEY}
       STORAGE_SECRET_KEY: ${STORAGE_SECRET_KEY}
-    ports:
-      - "8080:8080"
     volumes:
       - ./api:/app
     working_dir: /app
@@ -63,27 +63,31 @@ services:
     networks:
       - app_network
     depends_on:
+      db:
+        condition: service_healthy
       seaweedfs:
         condition: service_healthy
   db:
-    image: postgres
+    image: postgres:15
     container_name: postgres
     restart: always
     environment:
       POSTGRES_DB: ${POSTGRES_DB} # 環境変数から取得
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-    ports:
-      - ${POSTGRES_PORT}:5432
     volumes:
       - postgres-data:/var/lib/postgresql/data
     networks:
       - app_network
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
   seaweedfs:
     image: chrislusf/seaweedfs
     command: "server -s3"
-    ports:
-      - "8333:8333"
     volumes:
       - seaweedfs-data:/data
     networks:
@@ -109,13 +113,15 @@ services:
       SWAGGER_JSON: /openapi.yaml  # コンテナ内のパスを指定
   cloudflared:
     image: cloudflare/cloudflared:2025.8.1
-    command: tunnel --no-autoupdate --config /etc/cloudflared/config.yml run
+    command:
+      - tunnel
+      - --no-autoupdate
+      - run
+      - --token
+      - ${CLOUDFLARE_TUNNEL_TOKEN}
     restart: unless-stopped
-    volumes:
-      - /root/44th-workshop/cloudflared:/etc/cloudflared:ro
     networks:
       - app_network
-
 volumes:
   postgres-data:
   seaweedfs-data:


### PR DESCRIPTION
## 概要

本番環境でユーザー画面、管理画面、API、PostgreSQL、SeaweedFSを適切に接続するため、Docker ComposeとNext.jsの設定を修正しました。

Cloudflare Tunnelはローカルの設定ファイル方式から、Cloudflareダッシュボードで管理するトークン方式へ変更しています。

## 変更内容

### 管理画面からAPIへのプロキシを追加

`admin/next.config.ts`にrewriteを追加し、管理画面の`/api/*`へのリクエストをAPIコンテナへ転送するようにしました。

```text
https://hanabi-admin.nutfes.net/api/fireworks
↓
http://app:8080/fireworks
```

### docker-compose.prod.yamlの変更

以下の変更を`docker-compose.prod.yaml`に加えました。

- 管理画面へ以下の環境変数を渡すように変更
  - `NEXT_PUBLIC_API_URL`
  - `ADMIN_USERNAME`
  - `ADMIN_PASSWORD`
- API、PostgreSQL、SeaweedFSのホスト側ポート公開を削除し、Dockerネットワーク内のみで通信する構成に変更
- PostgreSQLのイメージを`postgres:15`に固定
- PostgreSQLへ`pg_isready`を使用したhealthcheckを追加
- APIコンテナを、PostgreSQLとSeaweedFSがhealthyになってから起動するように変更
- APIへSeaweedFSの内部接続先と公開URLを渡すように変更
  - 内部接続先: `http://seaweedfs:8333`
  - 公開URL: `STORAGE_PUBLIC_URL`
- Cloudflare Tunnelを、ローカルの設定ファイルをマウントする方式からTunnel Tokenを使用する方式へ変更
- Cloudflare Tunnelの公開ルートをCloudflareダッシュボード側で管理する構成に変更

本番環境の`.env`には、追加で以下の設定が必要です。

```env
# 管理画面からNext.jsのrewriteを経由してAPIへ接続する
API_BASE_URL=/api

# APIが画像URLを生成する際に使用するSeaweedFSの公開URL
STORAGE_PUBLIC_URL=https://hanabi-storage.nutfes.net

# Cloudflare Tunnelのトークン
# 公開ルートはCloudflareダッシュボードで管理する
CLOUDFLARE_TUNNEL_TOKEN=<token>
```

## 動作確認

- [x] `docker compose -f docker-compose.prod.yaml config`
- [x] 本番用Docker Composeによるイメージのビルド
- [x] 全コンテナの起動
- [x] PostgreSQLとSeaweedFSのhealthcheck成功
- [x] ユーザー画面からAPIへの接続
- [x] 管理画面から`/api`経由でAPIへ接続

## スクリーンショット
<img width="791" height="144" alt="image" src="https://github.com/user-attachments/assets/450dba36-58bb-4894-b411-a663a95dc99b" />

<img width="1118" height="95" alt="image" src="https://github.com/user-attachments/assets/4d4034a2-1fb7-4a19-bd02-27607665fffc" />
