### PR TITLE
Fix/ponyo/hanabi dashboard layout

### DIFF
--- a/admin/components/admin/FireworkListItem.tsx
+++ b/admin/components/admin/FireworkListItem.tsx
@@ -24,19 +24,19 @@ export default function FireworkListItem({
       style={fireworkItemStyle(isSelected)}
       onClick={() => onSelect(firework)}
     >
-      <div style={{ display: 'flex', gap: '0.5rem' }}>
-        <div style={{ fontWeight: 'bold', marginBottom: '0.5rem', color: '#2d3748' }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+        <div style={{ fontWeight: 'bold', marginBottom: '0.5rem', color: '#2d3748', minWidth: '5rem', flexShrink: 0 }}>
           🎆 花火 #{firework.id}
         </div>
         <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', marginBottom: '0.5rem' }}>
           <span style={statusBadgeStyle(firework.isShareable)}>
             {firework.isShareable ? '🌐 Shareable' : '🔒 Private'}
           </span>
-          <span style={{ fontSize: '0.75rem', color: '#718096' }}>
+          <span style={{ fontSize: '0.75rem', color: '#718096', minWidth: '6rem' }}>
             📅 {firework.createdAt ? new Date(firework.createdAt).toLocaleDateString() : 'N/A'}
           </span>
         </div>
-        <ImagePreview 
+        <ImagePreview
       imageUrl={imageUrl}
       size={50}
       />

--- a/admin/components/admin/FireworkListItem.tsx
+++ b/admin/components/admin/FireworkListItem.tsx
@@ -25,7 +25,7 @@ export default function FireworkListItem({
       onClick={() => onSelect(firework)}
     >
       <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-        <div style={{ fontWeight: 'bold', marginBottom: '0.5rem', color: '#2d3748', minWidth: '5rem', flexShrink: 0 }}>
+        <div style={{ fontWeight: 'bold', marginBottom: '0.5rem', color: '#2d3748', width: '6rem', flexShrink: 0, whiteSpace: 'nowrap' }}>
           🎆 花火 #{firework.id}
         </div>
         <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', marginBottom: '0.5rem' }}>

--- a/admin/components/admin/FireworkListItem.tsx
+++ b/admin/components/admin/FireworkListItem.tsx
@@ -25,7 +25,19 @@ export default function FireworkListItem({
       onClick={() => onSelect(firework)}
     >
       <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-        <div style={{ fontWeight: 'bold', marginBottom: '0.5rem', color: '#2d3748', width: '6rem', flexShrink: 0, whiteSpace: 'nowrap' }}>
+        <div
+          style={{
+            fontWeight: 'bold',
+            marginBottom: '0.5rem',
+            color: '#2d3748',
+            width: '6rem',
+            flexShrink: 0,
+            whiteSpace: 'nowrap',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+          }}
+          title={`花火 #${firework.id}`}
+        >
           🎆 花火 #{firework.id}
         </div>
         <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', marginBottom: '0.5rem' }}>
@@ -37,9 +49,9 @@ export default function FireworkListItem({
           </span>
         </div>
         <ImagePreview
-      imageUrl={imageUrl}
-      size={50}
-      />
+          imageUrl={imageUrl}
+          size={50}
+        />
       </div>
       
       <div>

--- a/admin/styles/adminStyles.ts
+++ b/admin/styles/adminStyles.ts
@@ -107,4 +107,7 @@ export const statusBadgeStyle = (isShareable: boolean): React.CSSProperties => (
   borderRadius: '12px',
   fontSize: '0.75rem',
   fontWeight: '600',
+  width: '5.5rem',
+  textAlign: 'center',
+  flexShrink: 0,
 });

--- a/admin/styles/adminStyles.ts
+++ b/admin/styles/adminStyles.ts
@@ -107,7 +107,8 @@ export const statusBadgeStyle = (isShareable: boolean): React.CSSProperties => (
   borderRadius: '12px',
   fontSize: '0.75rem',
   fontWeight: '600',
-  width: '5.5rem',
+  width: '6.5rem',
   textAlign: 'center',
   flexShrink: 0,
+  whiteSpace: 'nowrap',
 });

--- a/admin/styles/adminStyles.ts
+++ b/admin/styles/adminStyles.ts
@@ -108,6 +108,7 @@ export const statusBadgeStyle = (isShareable: boolean): React.CSSProperties => (
   fontSize: '0.75rem',
   fontWeight: '600',
   width: '6.5rem',
+  boxSizing: 'border-box',
   textAlign: 'center',
   flexShrink: 0,
   whiteSpace: 'nowrap',


### PR DESCRIPTION
## 概要
- 花火一覧の各行で、IDが1桁/2桁の場合や Private/Shareable のバッジ幅の違いにより、日付・画像サムネイルの横位置がずれる問題を修正
<img width="842" height="216" alt="スクリーンショット 2026-07-22 140400" src="https://github.com/user-attachments/assets/e25499bc-bd2f-41cf-b22f-e4aeb30a1bda" />

## 変更内容
- 花火一覧の各行で、IDの桁数によってタイトル部分の幅が変動し、バッジ・日付・画像サムネイルの横位置がずれる問題を修正
  - タイトル(🎆 花火 #N)を `width: 6rem` + `whiteSpace: nowrap` の固定幅にし、1桁/2桁いずれでも同じ幅を確保
- Private / Shareable バッジの文字数差によって幅が変動し、後続の日付・画像がずれる問題を修正
  - `statusBadgeStyle` に `width: 6.5rem` / `textAlign: center` / `whiteSpace: nowrap` を追加し、常に同じ幅・1行表示になるよう統一
- 日付表示部分にも `minWidth: 6rem` を追加し、表示位置を安定化

## 動作確認
-adminページでIDが1桁,2桁のときダッシュボードのズレがないか確認する
-Private,Shareableでダッシュボードにずれがないか確認する