### PR TITLE
[fix] update Go version to 1.26 and install specific air version

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25
+FROM golang:1.26
 
 WORKDIR /app
 
@@ -16,6 +16,12 @@ ENV GOOS=linux
 ENV LANG=ja_JP.UTF-8
 ENV LANGUAGE=en_US:
 
+# Airをインストール
+# NOTE: air は v1.67.2 以降 go >= 1.26.0 を要求する。
+#       air の pin を上げるときは上の FROM の Go バージョンも必ず確認すること。
+#       @latest は使わない（過去2回、air の Go 要求引き上げでビルドが壊れている: e360bd1 / 2026-07）
+RUN go install github.com/air-verse/air@v1.67.3
+
 # Go関連ファイルを先にコピー
 COPY go.mod go.sum ./
 RUN go mod download
@@ -29,9 +35,6 @@ RUN echo "=== Checking start.sh ===" && ls -la start.sh || echo "start.sh not fo
 
 # start.shに実行権限を付与（存在する場合）
 RUN if [ -f start.sh ]; then chmod +x start.sh; fi
-
-# Airをインストール
-RUN go install github.com/air-verse/air@latest
 
 # デフォルトコマンド（配列形式で指定）
 CMD ["/bin/bash", "./start.sh"]


### PR DESCRIPTION
buildが通らない問題を解消しました