### PR TITLE
Fix/walt/admin firework next id mismatch

### DIFF
--- a/admin/hooks/useFireworks.ts
+++ b/admin/hooks/useFireworks.ts
@@ -151,22 +151,25 @@ export function useFireworks() {
 
   // ---- API handlers ----
 
-  const fetchLatestId = useCallback(async () => {
+  // 花火の削除は論理削除であり、DBのID採番（シーケンス）は削除しても巻き戻らない。
+  // そのため「次のID」は削除済みを含めた最大IDをAPIから取得して算出する必要があり、
+  // 表示中（削除済みを除いた）の花火一覧から計算すると、直近削除したIDが最大だった場合に
+  // 実際にDBが採番するIDより小さい値を予測してしまう。API呼び出しに失敗した場合のみ、
+  // 苦肉の策として渡された一覧（fallbackList）から計算する。
+  const fetchLatestId = useCallback(async (fallbackList: Firework[] = fireworks) => {
     try {
       const response = await fetch(`${API_URL}/fireworks/latest-id`);
       if (response.ok) {
         const data = await response.json();
         const latestId = data.latestId || 0;
         setNextId(latestId + 1);
-      } else {
-        const maxId = fireworks.length > 0 ? Math.max(...fireworks.map(f => f.id)) : 0;
-        setNextId(maxId + 1);
+        return;
       }
     } catch (err) {
       console.warn('Failed to fetch latest ID, calculating from existing data:', err);
-      const maxId = fireworks.length > 0 ? Math.max(...fireworks.map(f => f.id)) : 0;
-      setNextId(maxId + 1);
     }
+    const maxId = fallbackList.length > 0 ? Math.max(...fallbackList.map(f => f.id)) : 0;
+    setNextId(maxId + 1);
   }, [API_URL, fireworks]);
 
   const fetchFireworks = useCallback(async () => {
@@ -187,13 +190,7 @@ export function useFireworks() {
       setFireworks(fireworksData);
 
       await loadAllImagesFromLocalStorage(fireworksData);
-
-      if (fireworksData.length > 0) {
-        const maxId = Math.max(...fireworksData.map((f: Firework) => f.id));
-        setNextId(maxId + 1);
-      } else {
-        setNextId(1);
-      }
+      await fetchLatestId(fireworksData);
 
       setError(null);
     } catch (err) {
@@ -205,7 +202,7 @@ export function useFireworks() {
     } finally {
       setLoading(false);
     }
-  }, [API_URL, loadAllImagesFromLocalStorage]);
+  }, [API_URL, loadAllImagesFromLocalStorage, fetchLatestId]);
 
   const selectFirework = useCallback((firework: Firework | null) => {
     setSelectedFirework(firework);

--- a/admin/hooks/useFireworks.ts
+++ b/admin/hooks/useFireworks.ts
@@ -280,7 +280,7 @@ export function useFireworks() {
   }, [selectedFile, isShareable, API_URL, fireworks, fetchFireworks, fetchLatestId, saveImageToLocalStorage]);
 
   const deleteFirework = useCallback(async (fireworkId: number) => {
-    if (!confirm(`Are you sure you want to delete firework #${fireworkId}? This action cannot be undone.`)) {
+    if (!confirm(`花火 #${fireworkId} を削除します。よろしいですか？この操作は取り消せません。`)) {
       return;
     }
 

--- a/admin/hooks/useFireworks.ts
+++ b/admin/hooks/useFireworks.ts
@@ -156,7 +156,10 @@ export function useFireworks() {
   // 表示中（削除済みを除いた）の花火一覧から計算すると、直近削除したIDが最大だった場合に
   // 実際にDBが採番するIDより小さい値を予測してしまう。API呼び出しに失敗した場合のみ、
   // 苦肉の策として渡された一覧（fallbackList）から計算する。
-  const fetchLatestId = useCallback(async (fallbackList: Firework[] = fireworks) => {
+  // fallbackList は呼び出し側に明示的に渡してもらう（state の fireworks を直接参照すると、
+  // この関数が fireworks の変更のたびに再生成され、これに依存する fetchFireworks も
+  // 再生成されて mount 時 useEffect が無限に再実行されてしまうため）。
+  const fetchLatestId = useCallback(async (fallbackList: Firework[]) => {
     try {
       const response = await fetch(`${API_URL}/fireworks/latest-id`);
       if (response.ok) {
@@ -170,7 +173,7 @@ export function useFireworks() {
     }
     const maxId = fallbackList.length > 0 ? Math.max(...fallbackList.map(f => f.id)) : 0;
     setNextId(maxId + 1);
-  }, [API_URL, fireworks]);
+  }, [API_URL]);
 
   const fetchFireworks = useCallback(async () => {
     setLoading(true);
@@ -189,8 +192,10 @@ export function useFireworks() {
       const fireworksData = Array.isArray(data) ? data : [];
       setFireworks(fireworksData);
 
-      await loadAllImagesFromLocalStorage(fireworksData);
-      await fetchLatestId(fireworksData);
+      await Promise.all([
+        loadAllImagesFromLocalStorage(fireworksData),
+        fetchLatestId(fireworksData),
+      ]);
 
       setError(null);
     } catch (err) {
@@ -230,7 +235,7 @@ export function useFireworks() {
 
     setIsCreating(true);
     try {
-      await fetchLatestId();
+      await fetchLatestId(fireworks);
 
       const formData = new FormData();
       formData.append('image', selectedFile);
@@ -272,7 +277,7 @@ export function useFireworks() {
     } finally {
       setIsCreating(false);
     }
-  }, [selectedFile, isShareable, API_URL, fetchFireworks, fetchLatestId, saveImageToLocalStorage]);
+  }, [selectedFile, isShareable, API_URL, fireworks, fetchFireworks, fetchLatestId, saveImageToLocalStorage]);
 
   const deleteFirework = useCallback(async (fireworkId: number) => {
     if (!confirm(`Are you sure you want to delete firework #${fireworkId}? This action cannot be undone.`)) {

--- a/api/handler/firework_handler.go
+++ b/api/handler/firework_handler.go
@@ -20,6 +20,7 @@ type fireworkHandler struct {
 type FireworkHandler interface {
 	GetFireworks(ctx echo.Context, params openapi.GetFireworksParams) error
 	GetFireworkById(ctx echo.Context, id int64, params openapi.GetFireworkByIdParams) error
+	GetLatestFireworkId(ctx echo.Context) error
 	CreateFirework(ctx echo.Context) error
 	DeleteFirework(ctx echo.Context, id int64) error
 	UpdateFirework(ctx echo.Context, id int64) error
@@ -52,6 +53,14 @@ func (h *fireworkHandler) GetFireworkById(ctx echo.Context, id int64, params ope
 		return ctx.JSON(http.StatusNotFound, map[string]string{"error": "not found"})
 	}
 	return ctx.JSON(http.StatusOK, firework)
+}
+
+func (h *fireworkHandler) GetLatestFireworkId(ctx echo.Context) error {
+	latestId, err := h.Usecase.GetLatestFireworkId(ctx.Request().Context())
+	if err != nil {
+		return ctx.JSON(http.StatusInternalServerError, map[string]string{"error": "failed to retrieve latest firework id"})
+	}
+	return ctx.JSON(http.StatusOK, openapi.LatestFireworkIdResponse{LatestId: latestId})
 }
 
 func (h *fireworkHandler) CreateFirework(ctx echo.Context) error {

--- a/api/openapi/openapi.gen.go
+++ b/api/openapi/openapi.gen.go
@@ -46,6 +46,12 @@ type FireworkUpdateRequest struct {
 	IsShareable bool `json:"isShareable"`
 }
 
+// LatestFireworkIdResponse 現在登録されている花火の最大ID（削除済みを含む）のレスポンス
+type LatestFireworkIdResponse struct {
+	// LatestId 花火が1件も存在しない場合は 0
+	LatestId int64 `json:"latestId"`
+}
+
 // GetFireworksParams クエリパラメータ
 type GetFireworksParams struct {
 	From *openapi_types.Date `form:"from,omitempty" json:"from,omitempty"`
@@ -65,6 +71,9 @@ type UpdateFireworkJSONRequestBody = FireworkUpdateRequest
 
 // ServerInterface represents all server handlers.
 type ServerInterface interface {
+	// 現在登録されている花火の最大ID（削除済みを含む）を取得する
+	// (GET /fireworks/latest-id)
+	GetLatestFireworkId(ctx echo.Context) error
 	// 花火の一覧を取得する
 	// (GET /fireworks)
 	GetFireworks(ctx echo.Context, params GetFireworksParams) error
@@ -103,6 +112,15 @@ func (w *ServerInterfaceWrapper) GetFireworks(ctx echo.Context) error {
 	}
 
 	err = w.Handler.GetFireworks(ctx, params)
+	return err
+}
+
+// GetLatestFireworkId converts echo context to params.
+func (w *ServerInterfaceWrapper) GetLatestFireworkId(ctx echo.Context) error {
+	var err error
+
+	// Invoke the callback with all the unmarshaled arguments
+	err = w.Handler.GetLatestFireworkId(ctx)
 	return err
 }
 
@@ -197,6 +215,7 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 		Handler: si,
 	}
 
+	router.GET(baseURL+"/fireworks/latest-id", wrapper.GetLatestFireworkId)
 	router.GET(baseURL+"/fireworks", wrapper.GetFireworks)
 	router.POST(baseURL+"/fireworks", wrapper.CreateFirework)
 	router.DELETE(baseURL+"/fireworks/:id", wrapper.DeleteFirework)

--- a/api/usecase/firework_usecase.go
+++ b/api/usecase/firework_usecase.go
@@ -27,6 +27,7 @@ type fireworkUsecase struct {
 type FireworkUsecase interface {
 	GetFireworks(ctx context.Context, from, to *time.Time) ([]openapi.FireworkResponse, error)
 	GetFireworkByID(ctx context.Context, id int64) (openapi.FireworkResponse, error)
+	GetLatestFireworkId(ctx context.Context) (int64, error)
 	CreateFirework(ctx context.Context, req openapi.FireworkCreateRequest) (openapi.FireworkResponse, error)
 	DeleteFirework(ctx context.Context, id int64) error
 	UpdateFirework(ctx context.Context, id int64, req openapi.FireworkUpdateRequest) (openapi.FireworkResponse, error)
@@ -92,6 +93,22 @@ func (uc *fireworkUsecase) GetFireworkByID(ctx context.Context, id int64) (opena
 		CreatedAt:   &fw.CreatedAt,
 		UpdatedAt:   &fw.UpdatedAt,
 	}, nil
+}
+
+// GetLatestFireworkId は、これまでに作成された花火の最大ID（削除済みを含む）を返す。
+// 論理削除（soft delete）で行が物理的に残り続けるうえ、DBの id はシーケンス採番で
+// 削除しても巻き戻らないため、"削除済みを除いた最大ID + 1" では実際に採番されるIDと
+// ズレる。Unscoped() で削除済み行も含めて MAX(id) を取ることで、DBの次の採番値と一致させる。
+func (uc *fireworkUsecase) GetLatestFireworkId(ctx context.Context) (int64, error) {
+	var latestId int64
+	if err := uc.db.WithContext(ctx).
+		Unscoped().
+		Model(&domain.Firework{}).
+		Select("COALESCE(MAX(id), 0)").
+		Scan(&latestId).Error; err != nil {
+		return 0, fmt.Errorf("failed to retrieve latest firework id: %w", err)
+	}
+	return latestId, nil
 }
 
 func (uc *fireworkUsecase) CreateFirework(ctx context.Context, req openapi.FireworkCreateRequest) (openapi.FireworkResponse, error) {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -8,6 +8,17 @@ servers:
   - url: http://app:8080
     description: Docker内部用サーバ
 paths:
+  /fireworks/latest-id:
+    get:
+      summary: "現在登録されている花火の最大ID（削除済みを含む）を取得する"
+      operationId: "GetLatestFireworkId"
+      responses:
+        '200':
+          description: "最大ID。花火が1件も存在しない場合は 0"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LatestFireworkIdResponse"
   /fireworks:
     get:
       summary: "花火の一覧を取得する"
@@ -120,6 +131,17 @@ paths:
           content: {}
 components:
   schemas:
+    LatestFireworkIdResponse:
+      type: object
+      description: "現在登録されている花火の最大ID（削除済みを含む）のレスポンス"
+      required:
+        - latestId
+      properties:
+        latestId:
+          type: integer
+          format: int64
+          description: "花火が1件も存在しない場合は 0"
+          example: 5
     FireworkCreateRequest:
       type: object
       description: "花火を作成するためのリクエストボディ"


### PR DESCRIPTION
## 概要
- 花火削除後、管理画面の「花火を作成」ボタン・「次に作成される花火ID」が実際に採番されるIDとズレて表示される不具合を修正
- 花火削除時の確認ダイアログが英語のまま表示される不具合を修正（develop から既存のバグ）

## 原因・変更内容

### 次に作成される花火IDのズレ
- 花火の削除は論理削除（`deleted_at` を立てるのみ）で行が物理的に残るため、DBの id（シーケンス採番）は削除しても巻き戻らない
- しかし管理画面は「表示中（削除済みを除く）の花火の最大ID + 1」で次のIDを予測しており、削除済みを含めた実際の採番値とズレていた
- 本来呼ぶはずだった `/fireworks/latest-id` がAPI側に未実装で常に404になり、上記の誤った計算に必ずフォールバックしていた

**変更内容:**
- `openapi.yaml` / `api/openapi/openapi.gen.go`: `GET /fireworks/latest-id` エンドポイントを追加
- `api/usecase/firework_usecase.go`: `GetLatestFireworkId` を追加。`Unscoped()` で論理削除済みの行も含めて `MAX(id)` を取得し、DBの実際の採番値と一致させる
- `api/handler/firework_handler.go`: 上記usecaseを呼び出すハンドラを追加
- `admin/hooks/useFireworks.ts`: `fetchFireworks` 内にあった重複・誤りのある「表示中データからmax+1を計算」処理を削除し、常に `fetchLatestId`（新エンドポイント）経由で次のIDを取得するよう統一
  - `fetchLatestId` の `fallbackList` を必須引数化し `useCallback` の依存配列から `fireworks` state を除去（`fireworks` に依存させたままだと `fetchFireworks` と相互再生成され、mount時の無限再フェッチループになるため）
  - `loadAllImagesFromLocalStorage` と `fetchLatestId` の直列 `await` を `Promise.all` で並列化